### PR TITLE
basic styling for summary page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@
 
 /*local*/
 @import 'local/phase-banner';
+@import 'local/tables';
 @import 'local/typography';
 @import 'local/buttons';
 @import 'local/rules';

--- a/app/assets/stylesheets/local/tables.scss
+++ b/app/assets/stylesheets/local/tables.scss
@@ -1,0 +1,3 @@
+table .right {
+  text-align: right;
+}

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -1,25 +1,33 @@
-h2 =t('summary_title')
+h1.heading-large =t('summary_title')
 
-p
-  | Status
-  =t("marital_status_#{@marital_status}")
+table
+  tbody
+    tr
+      td Status
+      td= t("marital_status_#{@marital_status}")
+      td.right= link_to "Change", "#"
+    tr
+      td Savings and investments
+      td= t("less_than_limit_#{@savings_and_investments}")
+      td.right= link_to "Change", "#"
+    tr
+      td Benefits
+      td= t("applicant_on_benefits_#{@benefits}")
+      td.right= link_to "Change", "#"
+    tr
+      td Fee paid
+      td=t("fee_paid_#{@fee}")
+      td.right= link_to "Change", "#"
+    tr
+      td Probate case
+      td=t("probate_case_#{@probate}")
+      td.right= link_to "Change", "#"
+    tr
+      td Claim number
+      td=t("claim_number_#{@claim}")
+      td.right= link_to "Change", "#"
 
-p
-  | Savings and investments
-  =t("less_than_limit_#{@savings_and_investments}")
+h2.heading-medium Declaration and statement of truth
+p By completing and sending this application, I believe the information I have given in this form is true to the best of my knowledge. If I am found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I understand that if I have given false information or I do not provide further evidence if requested, my application may be rejected and the full fee will be payable.
 
-p
-  | Benefits
-  =t("applicant_on_benefits_#{@benefits}")
-
-p
-  | Fee paid
-  =t("fee_paid_#{@fee}")
-
-p
-  | Probate case
-  =t("probate_case_#{@probate}")
-
-p
-  | Claim number
-  =t("claim_number_#{@claim}")
+a.button role="button" href="#" Complete and send application


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/112592235)

Summary page styling (not confirmation page, as mentioned on Pivotal - that's the page after this one).

All links ("Change" and the green button) go to # at the moment.

![screen shot 2016-02-12 at 11 00 33](https://cloud.githubusercontent.com/assets/988436/13005166/eab96bc4-d177-11e5-98e7-1b74659b338e.png)
