### PR TITLE
Added marital_status error handling

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -22,8 +22,10 @@ class HomeController < ApplicationController
       assign_attributes(instance, params[action.to_s.singularize])
       if instance.valid?
         save_in_session(instance)
+        session[:errors] = nil
         redirect_to next_step(action)
       else
+        session[:errors] = instance.errors
         redirect_to action
       end
     end
@@ -41,7 +43,11 @@ class HomeController < ApplicationController
   end
 
   def model_instance(model_name)
-    model_name.to_s.classify.constantize.new
+    model = model_name.to_s.classify.constantize.new
+    session[:errors].try(:each) do |attribute, message|
+      model.errors.add(attribute, message)
+    end
+    model
   end
 
   def assign_attributes(instance, params)

--- a/app/views/home/marital_status.html.slim
+++ b/app/views/home/marital_status.html.slim
@@ -1,7 +1,6 @@
 - if @marital_status.errors.any?
   .error-summary role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1"
     h1.heading-medium.error-summary-heading#error-summary-heading-example-1 You need to fix the errors on this page before continuing.
-    p See highlighted errors below.
     span.visuallyhidden Errors are listed as links below, click to select the field that needs correcting.
     ul.error-summary-list
       - @marital_status.errors.each do |field, message|

--- a/app/views/home/marital_status.html.slim
+++ b/app/views/home/marital_status.html.slim
@@ -1,11 +1,23 @@
+- if @marital_status.errors.any?
+  .error-summary role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1"
+    h1.heading-medium.error-summary-heading#error-summary-heading-example-1 You need to fix the errors on this page before continuing.
+    p See highlighted errors below.
+    span.visuallyhidden Errors are listed as links below, click to select the field that needs correcting.
+    ul.error-summary-list
+      - @marital_status.errors.each do |field, message|
+        li
+          - message = message.is_a?(Array) ? message.first : message
+          = link_to message, "##{field}", class: 'error-link', data: { id: "##{field}" }
+
 h2.heading-large
   span.heading-secondary Question 1
   | What's your status?
 
 = form_for @marital_status, url: marital_status_save_path do |f|
-  fieldset
+  fieldset class=('error' if @marital_status.errors[:married].any?)
     legend.visuallyhidden What's your status?
-
+    = f.hidden_field :married, value: nil
+    span.error-message#married =@marital_status.errors[:married].join(' ') if @marital_status.errors[:married].any?
     .form-group
       label.block-label for="marital_status_married_false"
         = f.radio_button :married, 'false'
@@ -38,4 +50,3 @@ h2.heading-large
 
   .form-group
     = f.submit t('submit_button'), class: 'button'
-

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,10 @@ module HwfPublicapp
     # The following values are required by the phase banner
     config.phase = 'alpha'
     config.feedback_url = '#'
+
+    # prevent fields being enclosed in field_with_error divs
+    config.action_view.field_error_proc = proc { |html_tag, _instance|
+      html_tag
+    }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,10 @@ en:
   personal_detail_title: Title
   personal_detail_first_name: First name
   personal_detail_last_name: Last name
+  activemodel:
+    errors:
+      models:
+        marital_status:
+          attributes:
+            married:
+              inclusion: 'Enter your marital status'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,4 +27,4 @@ en:
         marital_status:
           attributes:
             married:
-              inclusion: 'Enter your marital status'
+              inclusion: 'Select your marital status'

--- a/spec/features/pages/question_one_spec.rb
+++ b/spec/features/pages/question_one_spec.rb
@@ -1,0 +1,33 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.feature 'As a user' do
+  context 'when accessing the "marital_status" page for "Help with fees"' do
+    before { page.visit '/marital-status' }
+
+    context 'completing the form correctly' do
+      before do
+        choose 'marital_status_married_false'
+        click_button 'Continue'
+      end
+
+      scenario 'I expect to be routed to the "savings-and-investment" page' do
+        expect(page).to have_content 'How much do you have in savings and investments?'
+      end
+    end
+
+    context 'not completing the page correctly' do
+      before do
+        click_button 'Continue'
+      end
+
+      scenario 'I expect to be shown the "marital_status" page with error block' do
+        expect(page).to have_content 'You need to fix the errors on this page before continuing.'
+      end
+
+      scenario 'I expect the fields to have specific errors' do
+        expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter your marital status')
+      end
+    end
+  end
+end

--- a/spec/features/pages/question_one_spec.rb
+++ b/spec/features/pages/question_one_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'As a user' do
       end
 
       scenario 'I expect the fields to have specific errors' do
-        expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter your marital status')
+        expect(page).to have_xpath('//span[@class="error-message"]', text: 'Select your marital status')
       end
     end
   end


### PR DESCRIPTION
To do this, an error block is added to session and then re-loaded
on reloading the page.  On successful submission of the form, the
session variable is cleared.

I've added a proposal for feature tests by page to handle routing 
and error handling.  Happy to discuss, and possibly move back into
the uber feature tests if that is preferred.

This should probably be reviewed by:
@dotemacs as usual,
@axemonkey to check my css usage, and 
@leighmoney to check my words! 