### PR TITLE
Split locale files

### DIFF
--- a/app/views/home/marital_status.html.slim
+++ b/app/views/home/marital_status.html.slim
@@ -12,11 +12,11 @@ h2.heading-large
     .form-group
       label.block-label for="marital_status_married_false"
         = f.radio_button :married, 'false'
-        = t('married_false')
+        = t('married_false', scope: 'questions.marital_status')
 
       label.block-label for="marital_status_married_true"
         = f.radio_button :married, 'true'
-        = t('married_true')
+        = t('married_true', scope: 'questions.marital_status')
 
   .form-group
     details

--- a/app/views/home/marital_status.html.slim
+++ b/app/views/home/marital_status.html.slim
@@ -1,8 +1,8 @@
 = render('shared/error_block', form: @marital_status) if @marital_status.errors.any?
 
 h2.heading-large
-  span.heading-secondary Question 1
-  | What's your status?
+  span.heading-secondary =t('breadcrumb', scope: 'questions.marital_status')
+  =t('text', scope: 'questions.marital_status')
 
 = form_for @marital_status, url: marital_status_save_path do |f|
   fieldset class=('error' if @marital_status.errors.any?)
@@ -20,24 +20,24 @@ h2.heading-large
 
   .form-group
     details
-      summary Help with status
+      summary =t('details.summary', scope: 'questions.marital_status')
 
       .panel-indent
-        h3.heading-small Choose ‘married or living with someone and sharing an income’ if you’re:
+        h3.heading-small =t('heading', scope: 'questions.marital_status.details.section_1')
         ul.list.list-bullet
-          li married
-          li civil partners
-          li living together as if you are married or in a civil partnership
-          li living at the same address with a joint income
-          li a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care
+          li =t('item_1', scope: 'questions.marital_status.details.section_1')
+          li =t('item_2', scope: 'questions.marital_status.details.section_1')
+          li =t('item_3', scope: 'questions.marital_status.details.section_1')
+          li =t('item_4', scope: 'questions.marital_status.details.section_1')
+          li =t('item_5', scope: 'questions.marital_status.details.section_1')
 
-        h3.heading-small Choose ‘single’ if you rely on your own income or your case involves your partner, for example:
+        h3.heading-small = t('heading', scope: 'questions.marital_status.details.section_2')
         ul.list.list-bullet
-          li divorce, dissolution or annulment (unless you have married again or live with a new partner)
-          li gender recognition
-          li domestic violence
-          li forced marriage
-          li you and your partner are both part of a multiple fee group
+          li = t('item_1', scope: 'questions.marital_status.details.section_2')
+          li = t('item_2', scope: 'questions.marital_status.details.section_2')
+          li = t('item_3', scope: 'questions.marital_status.details.section_2')
+          li = t('item_4', scope: 'questions.marital_status.details.section_2')
+          li = t('item_5', scope: 'questions.marital_status.details.section_2')
 
   .form-group
     = f.submit t('submit_button'), class: 'button'

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -4,7 +4,7 @@ table
   tbody
     tr
       td Status
-      td= t("marital_status_#{@summary.marital_status_married}")
+      td= t("marital_status_#{@summary.marital_status_married}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
       td Savings and investments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,5 @@
 en:
   start_application: Apply now
-  married_true: Married or living with someone and sharing an income
-  married_false: Single
   submit_button: Continue
   summary_title: Check details
   marital_status_false: Single

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,6 @@ en:
   applicant_address_postcode: Postcode
   error_block:
     heading: 'You need to fix the errors on this page before continuing.'
-    sub_heading: 'See highlighted errors below.'
     visuallyhidden: 'Errors are listed as links below, click to select the field that needs correcting.'
   activemodel:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,10 @@ en:
   personal_detail_last_name: Last name
   applicant_address_address: Address
   applicant_address_postcode: Postcode
+  error_block:
+    heading: 'You need to fix the errors on this page before continuing.'
+    sub_heading: 'See highlighted errors below.'
+    visuallyhidden: 'Errors are listed as links below, click to select the field that needs correcting.'
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,8 +2,6 @@ en:
   start_application: Apply now
   submit_button: Continue
   summary_title: Check details
-  marital_status_false: Single
-  marital_status_true: Married or living with someone and sharing an income
   less_than_limit_false: Less than £3,000
   less_than_limit_true: More than £3,000
   on_benefits_false: 'No'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -1,0 +1,21 @@
+en:
+  questions:
+    marital_status:
+      breadcrumb: 'Question 1 of 14'
+      text: "What's your status?"
+      details:
+        summary: 'Help with status'
+        section_1:
+          heading: "Choose ‘married or living with someone and sharing an income’ if you’re:"
+          item_1: 'married'
+          item_2: 'civil partners'
+          item_3: 'living together as if you are married or in a civil partnership'
+          item_4: 'living at the same address with a joint income'
+          item_5: 'a couple forced to live apart, eg where one or both is serving in the Armed forces, in prison or living in residential care'
+        section_2:
+          heading: "‘single’ if you rely on your own income or your case involves your partner, for example:"
+          item_1: 'divorce, dissolution or annulment (unless you have married again or live with a new partner)'
+          item_2: 'gender recognition'
+          item_3: 'domestic violence'
+          item_4: 'forced marriage'
+          item_5: 'you and your partner are both part of a multiple fee group'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -1,6 +1,8 @@
 en:
   questions:
     marital_status:
+      married_true: 'Married or living with someone and sharing an income'
+      married_false: 'Single'
       breadcrumb: 'Question 1 of 14'
       text: "What's your status?"
       details:

--- a/config/locales/summary.yml
+++ b/config/locales/summary.yml
@@ -1,0 +1,4 @@
+en:
+  summary:
+    marital_status_false: Single
+    marital_status_true: Married or living with someone and sharing an income


### PR DESCRIPTION
This is a proposal for splitting the locale files for ease of use

The idea is that, ultimately, there will be the following files:
**en.yml** General file, activemodel, generic messaging
**question.yml** The text from the question pages grouped by subject
**summary.yml** Text for display on the summary page

Happy to discuss at any time...