### PR TITLE
add details polyfill

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery_ujs
 
 //= require govuk/selection-buttons
+//= require details.polyfill
 
 //= require_tree ./modules
 


### PR DESCRIPTION
Forgot this - needs to be included for `<details>` elements to work in non-Webkit browsers.