### PR TITLE
Using 'case' correctly

### DIFF
--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -106,8 +106,8 @@ en:
       text: 'Have you already paid the fee?'
       details: "You can apply for a refund for a fee paid in the last 3 months. If you’re applying for a refund, answer the following questions about your circumstances at the time you paid the fee."
     probate:
-      probate_kase_false: 'No'
-      probate_kase_true: 'Yes'
+      probate_case_false: 'No'
+      probate_case_true: 'Yes'
       breadcrumb: 'Question 7 of 14'
       text: 'Are you paying a fee for a probate case?'
       details: 'These cases are usually about the property and belongings of someone who has died.'


### PR DESCRIPTION
It's only reserved in the Ruby language, but not in the localisation
names.