### PR TITLE
extra NI info that was left out

### DIFF
--- a/app/views/home/national_insurance.html.slim
+++ b/app/views/home/national_insurance.html.slim
@@ -13,4 +13,15 @@ p Example: QQ 12 34 56 C
         = f.text_field :number, class: 'form-control transform-upper'
 
     .form-group
+      details
+        summary If you don’t know your National Insurance number
+
+        .panel-indent.text
+          ul.list.list-bullet
+            li look for your National Insurance number on payslips or official letters about tax, pensions or benefits
+            li= link_to 'ask for a reminder through the post', 'https://www.gov.uk/lost-national-insurance-number', class: 'external', rel: 'external'
+
+          p If you can’t provide a National Insurance number you will need to provide a letter from the job centre.
+
+    .form-group
       = f.submit t('submit_button'), class: 'button'


### PR DESCRIPTION
The extra info `<details>` panel for NI was missed out when creating the app content.

![screen shot 2016-02-18 at 11 25 51](https://cloud.githubusercontent.com/assets/988436/13142039/65281bbc-d632-11e5-90e7-8b777fb7385f.png)
