### PR TITLE
uppercase the NI field value with JS

### DIFF
--- a/app/assets/javascripts/modules/uppercase-fields.js
+++ b/app/assets/javascripts/modules/uppercase-fields.js
@@ -1,0 +1,24 @@
+'use strict';
+
+window.moj.Modules.UppercaseFields = {
+  init: function() {
+    var self = this,
+        $fields = $('.js-uppercase');
+
+    this.applyTransformClass($fields);
+    this.bindEvents($fields);
+  },
+
+  applyTransformClass: function($fields) {
+    $fields.addClass('transform-upper');
+  },
+
+  bindEvents: function($fields) {
+    $fields.each(function(n, field) {
+      var $field = $(field);
+      $field.on('blur', function() {
+        $field.val($field.val().toUpperCase());
+      });
+    });
+  }
+};

--- a/app/views/home/national_insurance.html.slim
+++ b/app/views/home/national_insurance.html.slim
@@ -10,7 +10,7 @@ p Example: QQ 12 34 56 C
     .form-group
       label.form-label for='national_insurance_number'
         span.visuallyhidden National Insurance number
-        = f.text_field :number, class: 'form-control transform-upper'
+        = f.text_field :number, class: 'form-control js-uppercase'
 
     .form-group
       details


### PR DESCRIPTION
Previously the css transform was showing the user uppercase letters, but lowercase were still being sent to the server, and failing validation. Now the transform is only applied if JS is present, and if it is, the value is uppercased by JS when focus leaves the field.