### PR TITLE
Improved error handling via the NI page

### DIFF
--- a/app/models/national_insurance.rb
+++ b/app/models/national_insurance.rb
@@ -1,7 +1,18 @@
 class NationalInsurance < Base
+  include ActiveModel::Validations::Callbacks
+
   attribute :number, String
 
   NI_NUMBER_REGEXP = /\A(?!BG|GB|NK|KN|TN|NT|ZZ)[ABCEGHJ-PRSTW-Z][ABCEGHJ-NPRSTW-Z]\d{6}[A-D]\z/
 
-  validates :number, format: { with: NI_NUMBER_REGEXP }, allow_blank: false
+  validates :number, format: { with: NI_NUMBER_REGEXP }, allow_blank: true
+  validates :number, presence: true
+
+  before_validation :format_number
+
+  def format_number
+    unless number.nil?
+      number.upcase!
+    end
+  end
 end

--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -2,31 +2,35 @@ module Views
   class Summary
 
     ATTRIBUTES = [
-      :marital_status_married,
-      :savings_and_investment_less_than_limit,
-      :benefit_on_benefits,
-      :fee_paid,
-      :probate_kase,
-      :claim_number,
-      :form_name_identifier,
-      :national_insurance_number,
-      :personal_detail_title,
-      :personal_detail_first_name,
-      :personal_detail_last_name,
-      :applicant_address_address,
-      :applicant_address_postcode,
-      :contact_email
+      { marital_status: 'married' },
+      { savings_and_investment: 'less_than_limit' },
+      { benefit: 'on_benefits' },
+      { fee: 'paid' },
+      { probate: 'kase' },
+      { claim: 'number' },
+      { form_name: 'identifier' },
+      { national_insurance: 'number' },
+      { personal_detail: 'title' },
+      { personal_detail: 'first_name' },
+      { personal_detail: 'last_name' },
+      { applicant_address: 'address' },
+      { applicant_address: 'postcode' },
+      { contact: 'email' }
     ].freeze
 
-    ATTRIBUTES.each do |attribute|
-      define_method(attribute.to_s) do
-        instance_variable_get("@#{attribute}")
+    ATTRIBUTES.each do |hash|
+      hash.each do |key, value|
+        define_method("#{key}_#{value}") do
+          instance_variable_get("@#{key}_#{value}")
+        end
       end
     end
 
     def initialize(session)
-      ATTRIBUTES.each do |attribute|
-        instance_variable_set("@#{attribute}", session[attribute])
+      ATTRIBUTES.each do |hash|
+        hash.each do |key, value|
+          instance_variable_set("@#{key}_#{value}", session[key][value]) if session[key]
+        end
       end
     end
 

--- a/app/views/home/national_insurance.html.slim
+++ b/app/views/home/national_insurance.html.slim
@@ -1,27 +1,29 @@
+= render('shared/error_block', form: @national_insurance) if @national_insurance.errors.any?
 h2.heading-large
-  span.heading-secondary Question 10 of 14
-  | What is your National Insurance number?
+  span.heading-secondary =t('breadcrumb', scope: @national_insurance.i18n_scope)
+  =t('text', scope: @national_insurance.i18n_scope)
 
-p Example: QQ 12 34 56 C
+p =t('example', scope: @national_insurance.i18n_scope)
 
 = form_for @national_insurance, url: national_insurance_save_path do |f|
   fieldset
-    legend.visuallyhidden What is your National Insurance number?
-    .form-group
+    legend.visuallyhidden =t('text', scope: @national_insurance.i18n_scope)
+    .form-group  class=('error' if @national_insurance.errors.any?)
       label.form-label for='national_insurance_number'
-        span.visuallyhidden National Insurance number
+        span.visuallyhidden =t('prompt', scope: @national_insurance.i18n_scope)
+        span.error-message#paid = @national_insurance.errors[:number].join(' ') if @national_insurance.errors[:number].any?
         = f.text_field :number, class: 'form-control js-uppercase'
 
     .form-group
       details
-        summary If you don’t know your National Insurance number
+        summary =t('summary', scope: "#{@national_insurance.i18n_scope}.details")
 
         .panel-indent.text
           ul.list.list-bullet
-            li look for your National Insurance number on payslips or official letters about tax, pensions or benefits
-            li= link_to 'ask for a reminder through the post', 'https://www.gov.uk/lost-national-insurance-number', class: 'external', rel: 'external'
+            li =t('item_1', scope: "#{@national_insurance.i18n_scope}.details.section_1")
+            li =link_to t('item_2', scope: "#{@national_insurance.i18n_scope}.details.section_1"), 'https://www.gov.uk/lost-national-insurance-number', class: 'external', rel: 'external'
 
-          p If you can’t provide a National Insurance number you will need to provide a letter from the job centre.
+          p =t('detail', scope: "#{@national_insurance.i18n_scope}.details.section_1")
 
     .form-group
       = f.submit t('submit_button'), class: 'button'

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -1,55 +1,55 @@
-h1.heading-large =t('title', scope: 'summary')
+h1.heading-large =t('title', scope: 'summary.labels')
 
 table
   tbody
     tr
-      td Status
+      td =t('married', scope: 'summary.labels')
       td= t("marital_status_#{@summary.marital_status_married}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
-      td Savings and investments
+      td =t('savings', scope: 'summary.labels')
       td= t("less_than_limit_#{@summary.savings_and_investment_less_than_limit}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
-      td Benefits
+      td =t('benefits', scope: 'summary.labels')
       td= t("applicant_on_benefits_#{@summary.benefit_on_benefits}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
-      td Fee paid
+      td =t('refund', scope: 'summary.labels')
       td=t("fee_paid_#{@summary.fee_paid}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
-      td Probate case
+      td =t('probate', scope: 'summary.labels')
       td=t("probate_case_#{@summary.probate_kase}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
-      td Claim number
+      td =t('claim', scope: 'summary.labels')
       td=t("claim_number_#{@summary.claim_number}")
       td.right= link_to "Change", "#"
     tr
-      td Form name
+      td =t('form_name', scope: 'summary.labels')
       td=@summary.form_name_identifier
       td.right= link_to "Change", "#"
     tr
-      td National insurance number
+      td =t('ni_number', scope: 'summary.labels')
       td =@summary.national_insurance_number
       td.right= link_to "Change", "#"
     tr
-      td Personal information
+      td =t('personal', scope: 'summary.labels')
       td =@summary.full_name
       td.right= link_to "Change", "#"
     tr
-      td Address
+      td =t('address', scope: 'summary.labels')
       td =@summary.full_address
       td.right= link_to "Change", "#"
     tr
-      td Email
+      td =t('contact', scope: 'summary.labels')
       td =@summary.contact_email
       td.right= link_to "Change", "#"
 
 
 
-h2.heading-medium Declaration and statement of truth
-p By completing and sending this application, I believe the information I have given in this form is true to the best of my knowledge. If I am found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I understand that if I have given false information or I do not provide further evidence if requested, my application may be rejected and the full fee will be payable.
+h2.heading-medium =t('heading', scope: 'summary.truth')
+p =t('statement', scope: 'summary.truth')
 
-a.button role="button" href="#" Complete and send application
+a.button role="button" href="#" =t('button', scope: 'summary.truth')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,8 @@ en:
           attributes:
             kase:
               inclusion: "Select whether you're paying a fee for a probate case"
+        national_insurance:
+          attributes:
+            number:
+              blank: 'Enter your National Insurance number'
+              invalid: 'Enter a valid National Insurance number'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -111,3 +111,14 @@ en:
       breadcrumb: 'Question 7 of 14'
       text: 'Are you paying a fee for a probate case?'
       details: 'These cases are usually about the property and belongings of someone who has died.'
+    national_insurance:
+      breadcrumb: 'Question 10 of 14'
+      text: 'What is your National Insurance number?'
+      example: "Example: QQ 12 34 56 C"
+      prompt: 'National Insurance number'
+      details:
+        summary: 'If you don’t know your National Insurance number'
+        section_1:
+          item_1: 'look for your National Insurance number on payslips or official letters about tax, pensions or benefits'
+          item_2: 'ask for a reminder through the post'
+          detail: 'If you can’t provide a National Insurance number you will need to provide a letter from the job centre.'

--- a/config/locales/summary.yml
+++ b/config/locales/summary.yml
@@ -1,6 +1,22 @@
 en:
   summary:
-    title: Check details
+    labels:
+      title: Check details
+      married: 'Status'
+      savings: 'Savings and investments'
+      benefits: 'Benefits'
+      refund: 'Fee paid'
+      probate: 'Probate case'
+      claim: 'Claim number'
+      form_name: 'Form name'
+      ni_number: 'National insurance number'
+      personal: 'Personal information'
+      address: 'Address'
+      contact: 'Email'
+    truth:
+      heading: 'Declaration and statement of truth'
+      statement: 'By completing and sending this application, I believe the information I have given in this form is true to the best of my knowledge. If I am found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I understand that if I have given false information or I do not provide further evidence if requested, my application may be rejected and the full fee will be payable.'
+      button: 'Complete and send application'
     marital_status_false: 'Single'
     marital_status_true: 'Married or living with someone and sharing an income'
     less_than_limit_false: 'Less than £3,000'

--- a/spec/features/pages/national_insurance_question_spec.rb
+++ b/spec/features/pages/national_insurance_question_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'As a user' do
           expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter your National Insurance number')
         end
       end
+
       describe 'providing an incorrect value' do
         before do
           fill_in :number, with: 'AB123'
@@ -38,6 +39,10 @@ RSpec.feature 'As a user' do
 
         scenario 'I expect the fields to have specific errors' do
           expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter a valid National Insurance number')
+        end
+
+        scenario 'I expect the incorrect data to be shown' do
+          expect(page).to have_xpath('//input[@id="national_insurance_number" and @value="AB123"]')
         end
       end
     end

--- a/spec/features/pages/national_insurance_question_spec.rb
+++ b/spec/features/pages/national_insurance_question_spec.rb
@@ -1,0 +1,45 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.feature 'As a user' do
+  context 'when accessing the "national-insurance" page for "Help with fees"' do
+    before { page.visit 'national-insurance' }
+
+    context 'completing the form correctly' do
+      before do
+        fill_in :number, with: 'AB123456A'
+        click_button 'Continue'
+      end
+
+      scenario 'I expect to be routed to the "personal-detail" page' do
+        expect(page).to have_content 'What is your full name?'
+      end
+    end
+
+    context 'not completing the page correctly' do
+      describe 'leaving the field empty' do
+        before do
+          click_button 'Continue'
+        end
+
+        scenario 'I expect to be shown the "national-insurance" page with error block' do
+          expect(page).to have_content 'You need to fix the errors on this page before continuing.'
+        end
+
+        scenario 'I expect the fields to have specific errors' do
+          expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter your National Insurance number')
+        end
+      end
+      describe 'providing an incorrect value' do
+        before do
+          fill_in :number, with: 'AB123'
+          click_button 'Continue'
+        end
+
+        scenario 'I expect the fields to have specific errors' do
+          expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter a valid National Insurance number')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/national_insurance_spec.rb
+++ b/spec/models/national_insurance_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe NationalInsurance, type: :model do
         it { expect(subject.valid?).to be true }
       end
 
+      context 'when provided in lower case' do
+        before { subject.number = 'ab123456a' }
+
+        it { expect(subject.valid?).to be true }
+
+        describe 'transforms the input to uppercase' do
+          before { subject.valid? }
+
+          it { expect(subject.number).to eql 'AB123456A' }
+        end
+      end
+
       context 'when provided with a space' do
         before { subject.number = 'AB123456A ' }
 

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 
 RSpec.describe Views::Summary do
 
-  let(:session) { { marital_status_married: 'true' } }
+  let(:session) {
+    { 'national_insurance' => { 'number' => 'AB123456A' },
+      'marital_status_married' => 'true' }
+  }
+
   subject { described_class.new(session) }
 
   it { is_expected.to respond_to :marital_status_married }

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 
 RSpec.describe Views::Summary do
 
-  let(:session) {
-    { 'national_insurance' => { 'number' => 'AB123456A' },
-      'marital_status_married' => 'true' }
-  }
+  let(:session) do
+    {
+      national_insurance: { number: 'AB123456A' },
+      marital_status: { married: 'true' }
+    }
+  end
 
   subject { described_class.new(session) }
 


### PR DESCRIPTION
tl;dr National Insurance validation works

While trying to update the error handling I realised that what we did not return the values to the page.  This worked fine while we only had unfilled checkboxes, but text fields needed something extra!

I have refactored the home controller to store all values in session[:model]['attribute'] and session[:model_errors]

We can now store multiple values and errors per model, while still loading them at the end of the process.

Now when a text value is invalid, the inputted text is returned to the user.