### PR TITLE
Locale helper

### DIFF
--- a/app/services/localise.rb
+++ b/app/services/localise.rb
@@ -1,0 +1,6 @@
+class Localise
+  def self.i18n(object, path)
+    ["questions.#{object.class.name.underscore}",
+     path].join '.'
+  end
+end

--- a/spec/services/localise_spec.rb
+++ b/spec/services/localise_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Localise do
+  describe '.i18n' do
+    let(:foo) do
+      class Foo; end
+      Foo.new
+    end
+
+    it 'returns the full i18n localisation path' do
+      expect(described_class.i18n(foo, 'bar')).to eq 'questions.foo.bar'
+    end
+  end
+end


### PR DESCRIPTION
Why: I wanted to clean up the Base class that all the objects inherit
from which has the i18n_scope method, as I feel that this functionality
violates the single responsibility principle.
