### PR TITLE
Case number extras

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,5 +1,10 @@
 class Claim < Base
   attribute :number, Boolean
+  attribute :identifier, String
 
   validates :number, inclusion: { in: [true, false] }
+
+  with_options if: :number do
+    validates :identifier, presence: true
+  end
 end

--- a/app/views/home/claim.html.slim
+++ b/app/views/home/claim.html.slim
@@ -1,9 +1,9 @@
 h2.heading-large
-  span.heading-secondary Question 8 of 14
-  | Do you have a case, claim or ‘notice to pay’ number?
+  span.heading-secondary =t('breadcrumb', scope: @claim.i18n_scope)
+  =t('text', scope: @claim.i18n_scope)
 
 p
-  | Find this number on letters from the court or tribunal.
+  =t('details', scope: @claim.i18n_scope)
 
 = form_for @claim, url: claim_save_path do |f|
   fieldset
@@ -12,10 +12,10 @@ p
     .form-group
       label.block-label for='claim_number_false'
         = f.radio_button :number, 'false'
-        = t('claim_number_false')
+        = t('number_false', scope: @claim.i18n_scope)
       label.block-label for='claim_number_true'
         = f.radio_button :number, 'true'
-        = t('claim_number_true')
+        = t('number_true', scope: @claim.i18n_scope)
 
     .form-group
       details

--- a/app/views/home/claim.html.slim
+++ b/app/views/home/claim.html.slim
@@ -16,6 +16,10 @@ p
       label.block-label for='claim_number_true'
         = f.radio_button :number, 'true'
         = t('number_true', scope: @claim.i18n_scope)
+      #claim-identifier-panel
+        label.form-label
+          = t('identifier', scope: @claim.i18n_scope)
+        = f.text_field :identifier, class: 'form-control'
 
     .form-group
       details

--- a/app/views/home/claim.html.slim
+++ b/app/views/home/claim.html.slim
@@ -3,11 +3,11 @@ h2.heading-large
   =t('text', scope: @claim.i18n_scope)
 
 p
-  =t('details', scope: @claim.i18n_scope)
+  =t('subtext', scope: @claim.i18n_scope)
 
 = form_for @claim, url: claim_save_path do |f|
   fieldset
-    legend.visuallyhidden Do you have a case, claim or ‘notice to pay’ number?
+    legend.visuallyhidden = t('hidden_legend', scope: @claim.i18n_scope)
 
     .form-group
       label.block-label for='claim_number_false'
@@ -19,14 +19,14 @@ p
 
     .form-group
       details
-        summary Help with case number
+        summary = t('details.summary', scope: @claim.i18n_scope)
 
         .panel-indent
-          p The court or tribunal creates a reference number for every case. This is sometimes called a claim number, case number, or ‘notice to pay’ number.
+          p = t('details.section_1', scope: @claim.i18n_scope)
 
-          p If your case is ongoing then you’ll find the reference number on letters from the court or tribunal.
+          p = t('details.section_2', scope: @claim.i18n_scope)
 
-          p If you don’t have a reference number (this might be because your case hasn’t started yet) leave this question blank.
+          p = t('details.section_3', scope: @claim.i18n_scope)
 
     .form-group
       = f.submit t('submit_button'), class: 'button'

--- a/app/views/home/claim.html.slim
+++ b/app/views/home/claim.html.slim
@@ -1,3 +1,4 @@
+= render('shared/error_block', form: @claim) if @claim.errors.any?
 h2.heading-large
   span.heading-secondary =t('breadcrumb', scope: @claim.i18n_scope)
   =t('text', scope: @claim.i18n_scope)
@@ -9,7 +10,7 @@ p
   fieldset
     legend.visuallyhidden = t('hidden_legend', scope: @claim.i18n_scope)
 
-    .form-group
+    .form-group class=('error' if @claim.errors.any?)
       label.block-label for='claim_number_false'
         = f.radio_button :number, 'false'
         = t('number_false', scope: @claim.i18n_scope)
@@ -18,6 +19,7 @@ p
         = t('number_true', scope: @claim.i18n_scope)
       #claim-identifier-panel
         label.form-label
+          span.error-message#identifier = @claim.errors[:identifier].join(' ') if @claim.errors[:identifier].any?
           = t('identifier', scope: @claim.i18n_scope)
         = f.text_field :identifier, class: 'form-control'
 

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -31,7 +31,7 @@ table
         td colspan="2" =@summary.probate_date_of_death
     tr
       td =t('claim', scope: 'summary.labels')
-      td=t("claim_number_#{@summary.claim_number}")
+      td =t("claim_number_#{@summary.claim_number}", scope: 'summary')
       td.right= link_to "Change", "#"
     tr
       td =t('form_name', scope: 'summary.labels')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,12 @@ en:
               not_a_date: "Enter the date in this format DD/MM/YYYY"
               before: "This date can't be in the future"
               after_or_equal_to: "The date of death must have been in the last 20 years"
+        claim:
+          attributes:
+            number:
+              inclusion: Select whether you have a case, claim or ‘notice to pay’ number
+            identifier:
+              blank: Enter a case, claim or ‘notice to pay’ number
         form_name:
           attributes:
             identifier:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,6 @@
 en:
   start_application: Apply now
   submit_button: Continue
-  claim_number_false: 'No'
-  claim_number_true: 'Yes'
   personal_detail_title: Title
   personal_detail_first_name: First name
   personal_detail_last_name: Last name

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -114,9 +114,15 @@ en:
     claim:
       breadcrumb: Question 8 of 14
       text: Do you have a case, claim or ‘notice to pay’ number?
-      details: Find this number on letters from the court or tribunal.
+      subtext: Find this number on letters from the court or tribunal.
+      hidden_legend: Do you have a case, claim or ‘notice to pay’ number?
       number_false: 'No'
       number_true: 'Yes'
+      details:
+        summary: Help with case number
+        section_1: The court or tribunal creates a reference number for every case. This is sometimes called a claim number, case number, or ‘notice to pay’ number.
+        section_2: If your case is ongoing then you’ll find the reference number on letters from the court or tribunal.
+        section_3: If you don’t have a reference number (this might be because your case hasn’t started yet) leave this question blank.
     form_name:
       breadcrumb: 'Question 9 of 14'
       text: 'What is the form name or number related to this application?'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -118,6 +118,7 @@ en:
       hidden_legend: Do you have a case, claim or ‘notice to pay’ number?
       number_false: 'No'
       number_true: 'Yes'
+      identifier: The case, claim or ‘notice to pay’ number is
       details:
         summary: Help with case number
         section_1: The court or tribunal creates a reference number for every case. This is sometimes called a claim number, case number, or ‘notice to pay’ number.

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -111,6 +111,12 @@ en:
       breadcrumb: 'Question 7 of 14'
       text: 'Are you paying a fee for a probate case?'
       details: 'These cases are usually about the property and belongings of someone who has died.'
+    claim:
+      breadcrumb: Question 8 of 14
+      text: Do you have a case, claim or ‘notice to pay’ number?
+      details: Find this number on letters from the court or tribunal.
+      number_false: 'No'
+      number_true: 'Yes'
     form_name:
       breadcrumb: 'Question 9 of 14'
       text: 'What is the form name or number related to this application?'

--- a/config/locales/summary.yml
+++ b/config/locales/summary.yml
@@ -29,3 +29,5 @@ en:
     fee_paid_true: 'Yes'
     probate_case_false: 'No'
     probate_case_true: 'Yes'
+    claim_number_false: 'No'
+    claim_number_true: 'Yes'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe HomeController, type: :controller do
   describe 'POST #claim_save' do
     context 'when parameters are valid' do
       it 'redirects to the next page' do
-        post :claim_save, claim: { number: 'true' }
+        post :claim_save, claim: { number: 'true', identifier: 'formy-form' }
         expect(response).to redirect_to(:form_name)
       end
     end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -6,21 +6,34 @@ RSpec.describe Claim, type: :model do
   describe 'validations' do
     describe 'number' do
       context 'when true' do
-        before { subject.number = true }
+        before do
+          subject.number = true
+          subject.identifier = 'formy-form'
+        end
 
-        it { expect(subject.valid?).to be true }
-      end
+        describe 'identifier' do
+          context 'when not provided' do
+            before { subject.identifier = '' }
 
-      context 'when false' do
-        before { subject.number = false }
+            it { expect(subject.valid?).to be false }
+          end
 
-        it { expect(subject.valid?).to be true }
-      end
+          context 'when provided' do
+            it { expect(subject.valid?).to be true }
+          end
+        end
 
-      context 'when not a boolean value' do
-        before { subject.number = 'string' }
+        context 'when false' do
+          before { subject.number = false }
 
-        it { expect(subject.valid?).to be false }
+          it { expect(subject.valid?).to be true }
+        end
+
+        context 'when not a boolean value' do
+          before { subject.number = 'string' }
+
+          it { expect(subject.valid?).to be false }
+        end
       end
     end
   end


### PR DESCRIPTION
Added attribute 'identifier' to Claim model which is meant to hold the
form number name in case the user chooses the option that states
that (s)he has made a case/claim/'notice to pay'.

Added tests for it and updated the locales.