### PR TITLE
Create JWT of summary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'govuk_elements_rails', git: 'https://github.com/ministryofjustice/govuk_ele
 gem 'moj_template', '~> 0.23.2'
 gem 'date_validator'
 gem 'jwt'
+gem 'config'
 # Use SCSS for stylesheets
 gem 'sass-rails', '5.0.4'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'govuk_frontend_toolkit', git: "https://github.com/alphagov/govuk_frontend_t
 gem 'govuk_elements_rails', git: 'https://github.com/ministryofjustice/govuk_elements_rails.git', submodules: true
 gem 'moj_template', '~> 0.23.2'
 gem 'date_validator'
+gem 'jwt'
 # Use SCSS for stylesheets
 gem 'sass-rails', '5.0.4'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jwt (1.5.2)
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -248,6 +249,7 @@ DEPENDENCIES
   govuk_frontend_toolkit!
   jbuilder (~> 2.0)
   jquery-rails
+  jwt
   launchy
   moj_template (~> 0.23.2)
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,9 +76,13 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.0)
+    config (1.0.0)
+      activesupport (>= 3.0)
+      deep_merge (~> 1.0.0)
     date_validator (0.8.1)
       activemodel
     debug_inspector (0.0.2)
+    deep_merge (1.0.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
@@ -244,6 +248,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   codeclimate-test-reporter
+  config
   date_validator
   govuk_elements_rails!
   govuk_frontend_toolkit!

--- a/app/builders/encode_and_encrypt.rb
+++ b/app/builders/encode_and_encrypt.rb
@@ -1,0 +1,33 @@
+class EncodeAndEncrypt
+
+  def initialize(object)
+    @object_to_encrypt = object
+    build_jwt
+  end
+
+  def encoded_jwt
+    encrypt_object
+  end
+
+  private
+
+  def build_jwt
+    issuer = Settings.encryption.issuer
+    audience = Settings.encryption.audience
+    pem = Settings.encryption.pem
+    key = OpenSSL::PKey.read(pem)
+
+    payload = { data: @object_to_encrypt.to_json, iss: issuer, aud: audience }
+    @jwt = JWT.encode payload, key, 'ES512'
+  end
+
+  def encrypt_object
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
+    cipher.encrypt
+    cipher.key = Settings.cipher.key
+    cipher.iv = Settings.cipher.iv
+    encrypted_string = cipher.update build_jwt
+    encrypted_string << cipher.final
+    [encrypted_string].pack('m')
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,8 @@
+encryption:
+  issuer: <%= ENV['ENCRYPTION_ISSUER'] %>
+  audience: <%= ENV['ENCRYPTION_AUDIENCE'] %>
+  pem: <%= ENV['ENCRYPTION_PEM'] %>
+  hmac: <%= ENV['HMAC'] %>
+cipher:
+  key: <%= ENV['CIPHER_KEY'] %>
+  iv: <%= ENV['CIPHER_IV'] %>

--- a/spec/builders/encode_and_encrypt_spec.rb
+++ b/spec/builders/encode_and_encrypt_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe EncodeAndEncrypt do
+  before do
+    allow(Settings.encryption).to receive(:issuer).and_return('hwf-public-app')
+    allow(Settings.encryption).to receive(:audience).and_return('fr-staff-app')
+    allow(Settings.encryption).to receive(:pem).and_return(private_key.to_pem)
+    allow(Settings.encryption).to receive(:hmac).and_return(SecureRandom.hex(64))
+    allow(Settings.cipher).to receive(:key).and_return(cipher.random_key)
+    allow(Settings.cipher).to receive(:iv).and_return(cipher.random_iv)
+  end
+
+  let(:private_key) do
+    ecdsa_key = OpenSSL::PKey::EC.new 'secp521r1'
+    ecdsa_key.generate_key
+    ecdsa_key
+  end
+
+  let(:public_key) do
+    ecdsa_public = OpenSSL::PKey::EC.new private_key
+    ecdsa_public.private_key = nil
+    ecdsa_public
+  end
+
+  let(:cipher) do
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
+    cipher.encrypt
+  end
+
+  let(:session) do
+    {
+      national_insurance: { 'number' => 'AB123456A' },
+      marital_status: { 'married' => 'true' }
+    }
+  end
+
+  let(:summary) { Views::Summary.new(session) }
+  subject(:encrypted_app) { described_class.new(summary) }
+
+  it { is_expected.to be_a described_class }
+
+  describe 'methods' do
+    describe '.encoded_jwt' do
+      subject(:encoded) { encrypted_app.encoded_jwt }
+
+      it { is_expected.to be_a String }
+
+      describe 'can be decoded using the passkey and iv' do
+        subject(:decrypted_token) do
+          cipher = OpenSSL::Cipher.new('aes-256-cbc')
+          cipher.decrypt
+          cipher.key = Settings.cipher.key
+          cipher.iv = Settings.cipher.iv
+          decrypted_string = cipher.update(encoded.unpack('m')[0])
+          decrypted_string << cipher.final
+        end
+
+        it { is_expected.to be_a String }
+
+        describe 'that can be decrypted' do
+          subject(:decoded_token) { JWT.decode(decrypted_token, public_key, true, algorithm: 'ES512') }
+
+          describe 'containing a data block' do
+            subject(:data) { JSON.parse(decoded_token[0]['data']) }
+
+            it { is_expected.to be_a Hash }
+
+            it 'with matching values' do
+              expect(data['national_insurance_number']).to eql 'AB123456A'
+              expect(data['marital_status_married']).to eql 'true'
+            end
+          end
+
+          describe 'claims' do
+            it 'raise an error if issuer does not match' do
+              expect {
+                JWT.decode decrypted_token, public_key, true, iss: 'foo-bar', verify_iss: true, algorithm: 'ES512'
+              }.to raise_error JWT::InvalidIssuerError
+            end
+
+            it 'raise an error if audience does not match' do
+              expect {
+                JWT.decode decrypted_token, public_key, true, aud: 'foo-bar', verify_aud: true, algorithm: 'ES512'
+              }.to raise_error JWT::InvalidAudError
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## This is a work in progress
This class takes a summary object and encrypts it into a JWT.
Once the process is complete, there'll be a separate class for POSTing to the staff app.
![hwf-encrption-flow](https://cloud.githubusercontent.com/assets/6757677/13316647/e9aa8e44-dba8-11e5-8e4f-8a2cb7f55404.png)

## Still to do
* test the other claims, audience, etc
* discuss with TA and security about proposal

## Future plans
* speak to platforms about using Vault, when it's ready!