### PR TITLE
Hide rspec.profile_examples locally

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  config.profile_examples = 10 if ENV['RACK_ENV']=='test'
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10 if ENV['RACK_ENV']=='test'
+  config.profile_examples = 10 if ENV['RACK_ENV'].eql?('test')
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
This means that travis (as it sets ENV['RACK_ENV'] to 'test') will still display them, but they won't run on local machines