### PR TITLE
fix for JS totalling bug

### DIFF
--- a/app/assets/javascripts/modules/income-table.js
+++ b/app/assets/javascripts/modules/income-table.js
@@ -14,9 +14,16 @@ window.moj.Modules.IncomeTable = {
   bindEvents: function() {
     var self = this;
 
-    self.$tables.find('input.form-control').on('change', function() {
+    self.$tables.find('input.form-control').on('keyup', function() {
       self.getTotalTables();
+    }).on('blur', function(e) {
+      self.formatValue($(e.target));
     });
+  },
+
+  formatValue: function($input) {
+    var val = parseFloat($input.val());
+    $input.val(val.toFixed(2));
   },
 
   getTotalTables: function() {
@@ -49,8 +56,6 @@ window.moj.Modules.IncomeTable = {
 
         if('' !== val && !Number.isNaN(val)) {
           columnTotal += val;
-          val = val.toFixed(2);
-          $input.val(val);
         }
       });
       totals[totals.length] = columnTotal.toFixed(2);


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/n/projects/1212124/stories/115027201)

Before the columns weren't totalling if the user's cursor was still in a value entry field. This fixes that.

Before
---
![screen shot 2016-03-04 at 11 02 09](https://cloud.githubusercontent.com/assets/988436/13525402/9f923bda-e1f8-11e5-97b7-4525a3c4afb4.png)

After
---
![screen shot 2016-03-04 at 11 02 29](https://cloud.githubusercontent.com/assets/988436/13525405/a5e829ae-e1f8-11e5-9ef5-1ce139b368bf.png)
