### PR TITLE
Tweaks to summary copy

### DIFF
--- a/config/locales/summary.yml
+++ b/config/locales/summary.yml
@@ -20,8 +20,8 @@ en:
       contact_post: 'Post'
     truth:
       heading: 'Declaration and statement of truth'
-      statement: 'By completing and sending this application, I believe the information I have given in this form is true to the best of my knowledge. If I am found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I understand that if I have given false information or I do not provide further evidence if requested, my application may be rejected and the full fee will be payable.'
-      button: 'Complete and send application'
+      statement: 'By completing this application, I believe the information I have given in this form is true to the best of my knowledge. If I am found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I understand that if I have given false information or I do not provide further evidence if requested, my application may be rejected and the full fee will be payable.'
+      button: 'Complete application'
     marital_status_false: 'Single'
     marital_status_true: 'Married or living with someone and sharing an income'
     less_than_limit_false: 'Less than £3,000'
@@ -34,4 +34,4 @@ en:
     probate_case_true: 'Yes'
     claim_number_false: 'No'
     claim_number_true: 'Yes'
-    contact_none: 'No contact requested'
+    contact_none: 'Contact details not provided'

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -529,7 +529,7 @@ RSpec.feature 'As a user' do
     expect(page).to have_content 'Bar'
     expect(page).to have_content 'Email'
     expect(page).to have_content 'foo@bar.com'
-    click_link 'Complete and send application'
+    click_link 'Complete application'
     expect(page).to have_content 'Your reference number is'
   end
 end

--- a/spec/features/user_details_are_not_persisted_spec.rb
+++ b/spec/features/user_details_are_not_persisted_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'User details are not persisted' do
   end
 
   def when_they_submit_the_application
-    click_link 'Complete and send application'
+    click_link 'Complete application'
   end
 
   def when_they_go_back_to_homepage_and_start_again


### PR DESCRIPTION
1. removed ‘send’ from button and statement of truth so that applicants
don’t think that the application is complete (as they need to send the
ref number to the court)
2. changed ‘ no contact requested’ to ‘contact details not provided’