### PR TITLE
only do calculations on number fields

### DIFF
--- a/app/assets/javascripts/modules/income-table.js
+++ b/app/assets/javascripts/modules/income-table.js
@@ -14,7 +14,7 @@ window.moj.Modules.IncomeTable = {
   bindEvents: function() {
     var self = this;
 
-    self.$tables.find('input.form-control').on('keyup', function() {
+    self.$tables.find('input.form-control[type="number"]').on('keyup', function() {
       self.getTotalTables();
     }).on('blur', function(e) {
       self.formatValue($(e.target));


### PR DESCRIPTION
Bug found by @firstaide – the JS calculcation events were being triggered on all `.form-control` fields on the income page, including the Other Income Description field, resulting in a `NaN` value when tabbing out of it. This fixes that by restricting the JS to fields with `type="number"`.