### PR TITLE
Nightwatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# node
+node_modules
+
+#nightwatch
+/tests/nightwatch/reports
+/tests/nightwatch/reports/*
+/tests/reports
+/tests/reports/*
+selenium-debug.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SPECS_PATH = ./tests/nightwatch/specs
+
+ifdef spec
+	specific_test = -t ${SPECS_PATH}/${spec}.js
+endif
+
+ifdef browser
+	environment = --env ${browser}
+endif
+
+# running tests on local env
+test:
+	./nightwatch -c tests/nightwatch/local.json ${environment} ${specific_test}
+test-chrome:
+	./nightwatch -c tests/nightwatch/local.json --env chrome ${specific_test}
+test-firefox:
+	./nightwatch -c tests/nightwatch/local.json --env firefox ${specific_test}

--- a/nightwatch
+++ b/nightwatch
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('nightwatch/bin/runner.js');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hwf-publicapp",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ministryofjustice/hwf-publicapp"
+  },
+  "engines": {
+    "node": ">=0.12.x"
+  },
+  "scripts": {},
+  "engineStrict": true,
+  "devDependencies": {
+    "nightwatch": "0.7.9",
+    "phantomjs": "2.1.3",
+    "require-dir": "^0.1.0",
+    "selenium-server-standalone-jar": "~2.48.2",
+    "moment": "^2.11.1"
+  }
+}

--- a/tests/nightwatch/commands/ensureCorrectPage.js
+++ b/tests/nightwatch/commands/ensureCorrectPage.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var log = require('../modules/log'),
+    util = require('util');
+
+exports.command = function(waitForSelector, pageUrl, textToContain, callback) {
+  var client = this;
+
+  this.perform(function() {
+    log.command('Checking the page is correct...');
+
+    client
+      .waitForElementVisible(waitForSelector, 5000,
+        '  - Page is ready'
+      )
+      .assert.urlContains(pageUrl,
+        util.format('  - URL contains %s', pageUrl)
+      );
+
+    if(typeof textToContain === 'object' && Object.keys(textToContain).length) {
+      Object.keys(textToContain).forEach(function(selector) {
+        client.assert.containsText(selector, textToContain[selector],
+          util.format('  - `%s` contains text \'%s\'', selector, textToContain[selector])
+        );
+      });
+    }
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/commands/nextPage.js
+++ b/tests/nightwatch/commands/nextPage.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var util = require('util');
+
+exports.command = function(callback) {
+  var client = this;
+
+  this.perform(function() {
+    client
+      .submitForm('form', function() {
+        console.log('     * Submit form');
+      })
+    ;
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/commands/radioSelect.js
+++ b/tests/nightwatch/commands/radioSelect.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var util = require('util');
+
+exports.command = function(fields, value, callback) {
+  var client = this;
+
+  this.perform(function() {
+    function clickOption(field, value) {
+      var el = util.format('input#%s_%s', field, value);
+      client.click(el, function() {
+        console.log(util.format('     * Setting "%s" to "%s"'), field, value);
+      });
+    }
+
+    if(fields.constructor === Array) {
+      fields.forEach(function(field) {
+        clickOption(field, value);
+      });
+    } else {
+      clickOption(fields, value);
+    }
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/commands/startService.js
+++ b/tests/nightwatch/commands/startService.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var log = require('../modules/log');
+
+exports.command = function(callback) {
+  var client = this;
+
+  this.perform(function() {
+    log.command('Starting the service...');
+
+    client
+      .deleteCookies()
+      .init()
+      .maximizeWindow()
+      .ensureCorrectPage('input.button-start', '', {
+        'h1': 'Apply for help with fees'
+      })
+      .pause(200)
+    ;
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/commands/testShowHideCheckbox.js
+++ b/tests/nightwatch/commands/testShowHideCheckbox.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var util = require('util');
+
+exports.command = function(checkbox, showElemId, callback) {
+  var client = this;
+
+  this.perform(function() {
+
+    client
+      // check checkbox is unchecked to start with
+      .element('id', checkbox, function(response) {
+        client.elementIdSelected(response.value.ELEMENT, function(result) {
+          client.assert.ok(!result.value, util.format('Checkbox #%s is not checked', checkbox));
+        });
+      })
+      // check showElem is hidden to start with
+      .assert.hidden(util.format('#%s', showElemId), util.format('  - #%s is hidden', showElemId))
+      // check box
+      .click(util.format('#%s', checkbox), function() {
+        console.log(util.format('     * Checking checkbox "%s" to "%s"'), checkbox);
+      })
+      // check showElem is revealed
+      .assert.visible(util.format('#%s', showElemId), util.format('  - #%s is visible', showElemId))
+    ;
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/commands/testShowHideRadio.js
+++ b/tests/nightwatch/commands/testShowHideRadio.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var util = require('util');
+
+exports.command = function(group, values, showElemId, callback) {
+  var client = this;
+
+  this.perform(function() {
+    function clickOption(field, value) {
+      var el = util.format('input#%s_%s', field, value);
+      client.click(el, function() {
+        console.log('     * Setting "' + field + '"' + ' to "' + value + '"');
+      });
+    }
+
+    // check showElem is hidden to start with
+    client.assert.hidden(util.format('#%s', showElemId), util.format('  - #%s is hidden', showElemId));
+
+    // check showElem is revealed when first value clicked
+    clickOption(group, values[0]);
+    client.waitForElementVisible(util.format('#%s', showElemId), util.format('  - #%s is visible', showElemId));
+
+    // check showElem is hidden when second value clicked
+    clickOption(group, values[1]);
+    client.assert.hidden(util.format('#%s', showElemId), util.format('  - #%s is hidden', showElemId));
+  });
+
+  if (typeof callback === 'function') {
+    callback.call(client);
+  }
+
+  return client;
+};

--- a/tests/nightwatch/custom_assertions/doesNotContainText.js
+++ b/tests/nightwatch/custom_assertions/doesNotContainText.js
@@ -1,0 +1,49 @@
+/**
+ * Checks if the given element does not contain the specified text.
+ *
+ * ```
+ *    this.demoTest = function (client) {
+ *      browser.assert.doesNotContainText('#main', 'The Night Watch');
+ *    };
+ * ```
+ *
+ * @method doesNotContainText
+ * @param {string} selector The selector (CSS / Xpath) used to locate the element.
+ * @param {string} expectedText The text to look for.
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
+ * @api assertions
+ */
+
+var util = require('util');
+exports.assertion = function(selector, expectedText, msg) {
+
+  var MSG_ELEMENT_NOT_FOUND = 'Testing if element <%s> contains text: "%s". ' +
+    'Element could not be located.';
+
+  this.message = msg || util.format('Testing if element <%s> does not contain text: "%s".', selector, expectedText);
+
+  this.expected = function() {
+    return expectedText;
+  };
+
+  this.pass = function(value) {
+    return value.indexOf(expectedText) === -1;
+  };
+
+  this.failure = function(result) {
+    var failed = result === false || result && result.status === -1;
+    if (failed) {
+      this.message = msg || util.format(MSG_ELEMENT_NOT_FOUND, selector, expectedText);
+    }
+    return failed;
+  };
+
+  this.value = function(result) {
+    return result.value;
+  };
+
+  this.command = function(callback) {
+    return this.api.getText(selector, callback);
+  };
+
+};

--- a/tests/nightwatch/custom_assertions/urlNotEqual.js
+++ b/tests/nightwatch/custom_assertions/urlNotEqual.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var util = require('util');
+
+exports.assertion = function(expected, msg) {
+  this.message = msg || util.format('Testing if the URL not equals "%s".', expected);
+  this.expected = expected;
+
+  this.pass = function(value) {
+    return value !== this.expected;
+  };
+
+  this.value = function(result) {
+    return result.value;
+  };
+
+  this.command = function(callback) {
+    this.api.url(callback);
+    return this;
+  };
+
+};

--- a/tests/nightwatch/local.json
+++ b/tests/nightwatch/local.json
@@ -1,0 +1,50 @@
+{
+  "src_folders" : "tests/nightwatch/specs",
+  "output_folder" : "tests/nightwatch/reports",
+  "custom_assertions_path" : "tests/nightwatch/custom_assertions",
+  "custom_commands_path" : "tests/nightwatch/commands",
+
+  "selenium" : {
+    "cli_args" : {
+      "webdriver.firefox.profile" : "nightwatch"
+    },
+    "start_process" : true,
+    "server_path" : "node_modules/selenium-server-standalone-jar/jar/selenium-server-standalone-2.48.2.jar"
+  },
+
+  "test_settings" : {
+    "default" : {
+      "launch_url" : "http://localhost:3000",
+      "silent": true,
+      "globals" : {
+        "waitForConditionTimeout" : 2000
+      },
+      "desiredCapabilities": {
+        "browserName": "phantomjs",
+        "javascriptEnabled" : true,
+        "acceptSslCerts" : true,
+        "phantomjs.binary.path" : "node_modules/phantomjs/bin/phantomjs"
+      }
+    },
+
+    "firefox" : {
+      "screenshots" : {
+        "enabled" : true,
+        "path" : "tests/reports/nightwatch/screenshots"
+      },
+      "desiredCapabilities": {
+        "browserName": "firefox"
+      }
+    },
+
+    "chrome" : {
+      "screenshots" : {
+        "enabled" : true,
+        "path" : "tests/reports/nightwatch/screenshots"
+      },
+      "desiredCapabilities": {
+        "browserName": "chrome"
+      }
+    }
+  }
+}

--- a/tests/nightwatch/modules/log.js
+++ b/tests/nightwatch/modules/log.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.command = function() {
+  var args = Array.prototype.slice.call(arguments);
+  args.unshift(' -->');
+
+  console.log.apply(console, args);
+};

--- a/tests/nightwatch/specs/happypath-test-show-hide.js
+++ b/tests/nightwatch/specs/happypath-test-show-hide.js
@@ -1,0 +1,162 @@
+'use strict';
+
+module.exports = {
+  'Start': function(client) {
+    client
+      .startService()
+      .click('input.button-start', function() {
+        console.log('     * Click start button');
+      })
+    ;
+  },
+
+  'Marital status': function(client) {
+    client
+      .ensureCorrectPage('form.new_marital_status', '/marital-status', {
+        'h2': 'Question 1 of 14'
+      })
+      .radioSelect('marital_status_married', 'true')
+      .nextPage()
+    ;
+  },
+
+  'Savings and investments': function(client) {
+    client
+      .ensureCorrectPage('form.new_savings_and_investment', '/savings-and-investment', {
+        'h2': 'Question 2 of 14'
+      })
+      .radioSelect('savings_and_investment_less_than_limit', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Benefits': function(client) {
+    client
+      .ensureCorrectPage('form.new_benefit', '/benefit', {
+        'h2': 'Question 3 of 14'
+      })
+      .radioSelect('benefit_on_benefits', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Children': function(client) {
+    client
+      .ensureCorrectPage('form.new_dependent', '/dependent', {
+        'h2': 'Question 4 of 14'
+      })
+      .testShowHideRadio('dependent_children', ['true', 'false'], 'dependent-children_number-panel')
+      .radioSelect('dependent_children', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Income': function(client) {
+    client
+      .ensureCorrectPage('form.new_income', '/income', {
+        'h2': 'Question 5 of 14'
+      })
+      .nextPage()
+    ;
+  },
+
+  'Refund': function(client) {
+    client
+      .ensureCorrectPage('form.new_fee', '/fee', {
+        'h2': 'Question 6 of 14'
+      })
+      .testShowHideRadio('fee_paid', ['true', 'false'], 'date-fee-paid-panel')
+      .radioSelect('fee_paid', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Probate': function(client) {
+    client
+      .ensureCorrectPage('form.new_probate', '/probate', {
+        'h2': 'Question 7 of 14'
+      })
+      .testShowHideRadio('probate_kase', ['true', 'false'], 'probate-details-panel')
+      .radioSelect('probate_kase', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Claim': function(client) {
+    client
+      .ensureCorrectPage('form.new_claim', '/claim', {
+        'h2': 'Question 8 of 14'
+      })
+      .testShowHideRadio('claim_number', ['true', 'false'], 'claim-identifier-panel')
+      .radioSelect('claim_number', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Form name': function(client) {
+    client
+      .ensureCorrectPage('form.new_form_name', '/form-name', {
+        'h2': 'Question 9 of 14'
+      })
+      .nextPage()
+    ;
+  },
+
+  'NI number': function(client) {
+    client
+      .ensureCorrectPage('form.new_national_insurance', '/national-insurance', {
+        'h2': 'Question 10 of 14'
+      })
+      .setValue('#national_insurance_number', 'AB123456C')
+      .nextPage()
+    ;
+  },
+
+  'Date of birth': function(client) {
+    client
+      .ensureCorrectPage('form.new_dob', '/dob', {
+        'h2': 'Question 11 of 14'
+      })
+      .setValue('#dob_date_of_birth', '01/01/1980')
+      .nextPage()
+    ;
+  },
+
+  'Personal detail': function(client) {
+    client
+      .ensureCorrectPage('form.new_personal_detail', '/personal-detail', {
+        'h2': 'Question 12 of 14'
+      })
+      .setValue('#personal_detail_first_name', 'Test')
+      .setValue('#personal_detail_last_name', 'Tester')
+      .nextPage()
+    ;
+  },
+
+  'Address': function(client) {
+    client
+      .ensureCorrectPage('form.new_applicant_address', '/applicant-address', {
+        'h2': 'Question 13 of 14'
+      })
+      .setValue('#applicant_address_address', '1 Test Street')
+      .setValue('#applicant_address_postcode', 'TE37 1NG')
+      .nextPage()
+    ;
+  },
+
+  'Contact': function(client) {
+    client
+      .ensureCorrectPage('form.new_contact', '/contact', {
+        'h2': 'Question 14 of 14'
+      })
+      .testShowHideCheckbox('contact_email_option', 'email-field-panel')
+      .testShowHideCheckbox('contact_phone_option', 'phone-number-panel')
+    ;
+  },
+
+  'End': function(client) {
+    client
+      .end()
+    ;
+  }
+};

--- a/tests/nightwatch/specs/income-table.js
+++ b/tests/nightwatch/specs/income-table.js
@@ -1,0 +1,100 @@
+'use strict';
+
+module.exports = {
+  'Start': function(client) {
+    client
+      .startService()
+      .click('input.button-start', function() {
+        console.log('     * Click start button');
+      })
+    ;
+  },
+
+  'Marital status': function(client) {
+    client
+      .ensureCorrectPage('form.new_marital_status', '/marital-status', {
+        'h2': 'Question 1 of 14'
+      })
+      .radioSelect('marital_status_married', 'true')
+      .nextPage()
+    ;
+  },
+
+  'Savings and investments': function(client) {
+    client
+      .ensureCorrectPage('form.new_savings_and_investment', '/savings-and-investment', {
+        'h2': 'Question 2 of 14'
+      })
+      .radioSelect('savings_and_investment_less_than_limit', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Benefits': function(client) {
+    client
+      .ensureCorrectPage('form.new_benefit', '/benefit', {
+        'h2': 'Question 3 of 14'
+      })
+      .radioSelect('benefit_on_benefits', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Children': function(client) {
+    client
+      .ensureCorrectPage('form.new_dependent', '/dependent', {
+        'h2': 'Question 4 of 14'
+      })
+      .testShowHideRadio('dependent_children', ['true', 'false'], 'dependent-children_number-panel')
+      .radioSelect('dependent_children', 'false')
+      .nextPage()
+    ;
+  },
+
+  'Income': function(client) {
+    client
+      .ensureCorrectPage('form.new_income', '/income', {
+        'h2': 'Question 5 of 14'
+      })
+    ;
+  },
+
+  'Test income table': function(client) {
+    client
+      // check totals are visible and are 0.00
+      .assert.visible('table.income tfoot')
+      .assert.containsText('table.income tfoot td:nth-child(2)', '£0.00a month')
+      .assert.containsText('table.income tfoot td:nth-child(3)', '£0.00a month')
+      // click into first value input
+      .click('table.income tbody tr:nth-child(1) td:nth-child(2) input')
+      // check that typing numbers updates the totals
+      .keys('123')
+      .assert.containsText('table.income tfoot td:nth-child(2)', '123.00')
+      .assert.containsText('table.income tfoot td:nth-child(3)', '0.00')
+      .keys([client.Keys.TAB, '4.56'])
+      .assert.containsText('table.income tfoot td:nth-child(2)', '123.00')
+      .assert.containsText('table.income tfoot td:nth-child(3)', '4.56')
+      // check that a value in the next row is totalled up
+      .keys([client.Keys.TAB, '78.90'])
+      .assert.containsText('table.income tfoot td:nth-child(2)', '201.90')
+      .assert.containsText('table.income tfoot td:nth-child(3)', '4.56')
+      // try a few different entries in the second column
+      .keys([client.Keys.TAB, '000000.9'])
+      .assert.containsText('table.income tfoot td:nth-child(3)', '5.46')
+      .keys([client.Keys.TAB, client.Keys.TAB, '1.23456789'])
+      .assert.containsText('table.income tfoot td:nth-child(3)', '6.69')
+      .keys([client.Keys.TAB, client.Keys.TAB, '10'])
+      .assert.containsText('table.income tfoot td:nth-child(3)', '16.69')
+      .keys(client.Keys.BACK_SPACE)
+      .assert.containsText('table.income tfoot td:nth-child(3)', '7.69')
+      .keys([client.Keys.TAB, client.Keys.TAB, 'abcdefg'])
+      .assert.containsText('table.income tfoot td:nth-child(3)', '7.69')
+    ;
+  },
+
+  'End': function(client) {
+    client
+      .end()
+    ;
+  }
+};


### PR DESCRIPTION
Have added Nightwatch to the public app to help catch JS regressions. Tests provided for the show/hide functionality and the JS income table.

No CI integration at the moment, but at least it's here. Could be added to CI at some point in the future, but requires a running rails instance to run the tests against (we have the same situation with the staff app).