### PR TITLE
Clear session only when complete

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,11 +17,6 @@ class HomeController < ApplicationController
   def index
   end
 
-  def create
-    clear_data
-    redirect_to(action: ACTIONS.first)
-  end
-
   ACTIONS.each do |action|
     define_method(action.to_s) do
       instance_variable_set("@#{action}", model_from_params(action))
@@ -48,7 +43,7 @@ class HomeController < ApplicationController
 
   def confirmation
     @response = { result: true, message: 'HWF-16-1234' }
-    clear_data
+    reset_session
   end
 
   private
@@ -76,9 +71,5 @@ class HomeController < ApplicationController
 
   def next_step(action)
     ::Navigation.new.steps[action]
-  end
-
-  def clear_data
-    session.clear
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -48,8 +48,7 @@ ul.list.list-bullet
 
 p Applying takes around 10 minutes. This service is for England and Wales only.
 
-= form_tag(apply_path, method: :post) do
-  = submit_tag(t('start_application'), class: 'button button-start', role: 'button')
+a.button.button-start role="button" href='marital-status' =t('start_application')
 
 h2.heading-large Other ways to apply
 p You can also apply by post using the #{link_to '‘Apply for help with fees (EX160)’ (PDF 82KB)', 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160-eng-20160212.pdf', class: 'external', rel: 'external'} form.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'home#index'
-  post 'apply' => 'home#create'
+
   get 'summary' => 'home#summary'
   get 'confirmation' => 'home#confirmation'
 

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 RSpec.feature 'As a user' do
   scenario 'I want to start the application for "Help with fees"' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
   end
 
   scenario 'I want to add my marital status' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -17,7 +17,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on my savings and investments' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -28,7 +28,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on benefits' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -42,7 +42,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on dependents' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -59,7 +59,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on income' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -79,7 +79,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on fee payment' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -102,7 +102,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on probate case' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -128,7 +128,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add my national insurance number' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -157,7 +157,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add information on case or claim' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -189,7 +189,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add national insurance number' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -224,7 +224,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add my date of birth' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -262,7 +262,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add my personal information' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -305,7 +305,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add my address' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -352,7 +352,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to add my prefered contact option' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -403,7 +403,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to see the summary of my application' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'
@@ -468,7 +468,7 @@ RSpec.feature 'As a user' do
 
   scenario 'I want to see a confirmation of my application' do
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     expect(page).to have_content "Are you single, married or living with someone and sharing an income?"
     choose 'marital_status_married_false'
     click_button 'Continue'

--- a/spec/features/user_details_are_not_persisted_spec.rb
+++ b/spec/features/user_details_are_not_persisted_spec.rb
@@ -8,15 +8,9 @@ RSpec.feature 'User details are not persisted' do
     then_their_data_is_not_persisted
   end
 
-  scenario 'User starts the application again and all the previous data is cleared out of the session' do
-    given_user_starts_an_application
-    when_they_go_back_to_homepage_and_start_again
-    then_their_data_is_not_persisted
-  end
-
   def given_user_provides_all_data
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     choose 'marital_status_married_false'
     click_button 'Continue'
     choose 'savings_and_investment_less_than_limit_false'
@@ -53,7 +47,7 @@ RSpec.feature 'User details are not persisted' do
 
   def given_user_starts_an_application
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
     choose 'marital_status_married_false'
     click_button 'Continue'
   end
@@ -64,7 +58,7 @@ RSpec.feature 'User details are not persisted' do
 
   def when_they_go_back_to_homepage_and_start_again
     visit '/'
-    click_button 'Apply now'
+    click_link_or_button 'Apply now'
   end
 
   def then_their_data_is_not_persisted


### PR DESCRIPTION
Because we don't know if our system will be rendering the start page, or if it will be served from GOV.UK, we can't have a dynamic form on it. So the start button becomes just a GET link again, until that decision is made. 

Also I think clearing out session in a GET method is not a good practice, so I've just narrowed it down to be cleared when the data is submitted in the end. The start button session clearing was useful for the user testing, but there's no real need. The session should have a reasonably short expiration itself, to prevent multiple users on the same computer to potentially access their data.