### PR TITLE
front-end for contact page changes

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,32 +1,20 @@
 class Contact < Base
-  attribute :email_option, Boolean, default: false
   attribute :email, String
-  attribute :phone_option, Boolean, default: false
-  attribute :phone, String
-  attribute :post_option, Boolean, default: false
+  attribute :feedback_opt_in, Boolean, default: false
 
-  validates :email_option, inclusion: { in: [true, false] }
-  validates :phone_option, inclusion: { in: [true, false] }
-  validates :post_option, inclusion: { in: [true, false] }
-
-  with_options if: :email_option? do
-    email_regex = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-    validates :email, format: { with: email_regex, allow_nil: false }
-  end
-
-  with_options if: :phone_option? do
-    validates :phone, presence: true
-  end
+  email_regex = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  validates :email, format: { with: email_regex, allow_nil: true, allow_blank: true }
+  validates :feedback_opt_in, inclusion: { in: [true, false] }
 
   private
 
   def export_params
     {
-      email_contact: email_option,
-      email_address: email_option ? email : nil,
-      phone_contact: phone_option,
-      phone: phone_option ? phone : nil,
-      post_contact: post_option
+      email_contact: email.present?,
+      email_address: email,
+      phone_contact: false,
+      post_contact: false,
+      feedback_opt_in: feedback_opt_in
     }
   end
 end

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -25,4 +25,5 @@ class OnlineApplication
   attribute :phone_contact, Boolean
   attribute :phone, String
   attribute :post_contact, Boolean
+  attribute :feedback_opt_in, Boolean
 end

--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -23,11 +23,8 @@ module Views
       { personal_detail: 'last_name' },
       { applicant_address: 'address' },
       { applicant_address: 'postcode' },
-      { contact: 'email_option' },
       { contact: 'email' },
-      { contact: 'phone_option' },
-      { contact: 'phone' },
-      { contact: 'post_option' }
+      { contact: 'feedback_opt_in' }
     ].freeze
 
     ATTRIBUTES.each do |hash|
@@ -65,10 +62,6 @@ module Views
     def full_address
       [@applicant_address_address,
        @applicant_address_postcode].join(' ')
-    end
-
-    def any_contact
-      @contact_email_option || @contact_phone_option || @contact_post_option
     end
 
     def probate_date_of_death

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -61,22 +61,11 @@ table
       td =t('address', scope: 'summary.labels')
       td =@summary.full_address
       td.right= link_to "Change", question_path(:applicant_address)
-    -if @summary.any_contact
-      -if @summary.contact_email_option
-        tr
-          td =t('contact_email', scope: 'summary.labels')
-          td =@summary.contact_email
-          td.right= link_to "Change", question_path(:contact)
-      -if @summary.contact_phone_option
-        tr
-          td =t('contact_phone', scope: 'summary.labels')
-          td =@summary.contact_phone
-          td.right= link_to "Change", question_path(:contact)
-      -if @summary.contact_post_option
-        tr
-          td =t('contact_post', scope: 'summary.labels')
-          td Yes
-          td.right= link_to "Change", question_path(:applicant_address)
+    -if @summary.contact_email.present?
+      tr
+        td =t('contact_email', scope: 'summary.labels')
+        td =@summary.contact_email
+        td.right= link_to "Change", question_path(:contact)
     -else
       tr
         td = t('contact', scope: 'summary.labels')

--- a/app/views/questions/_contact.html.slim
+++ b/app/views/questions/_contact.html.slim
@@ -10,28 +10,15 @@ h2.heading-large
     .form-group
       p = t('details', scope: @form.i18n_scope)
 
-    .form-group
-      label.block-label data-target="email-field-panel"
+    .form-group class=('error' if @form.errors[:email].any?)
+      = f.label :email, t('email_label', scope: @form.i18n_scope), class: 'form-label'
+      span.error-message#email = @form.errors[:email].join(' ') if @form.errors[:email].any?
+      = f.text_field :email, class: 'form-control'
+
+    .form-group.text
+      label
         = f.check_box :email_option
-        = t('email_option', scope: @form.i18n_scope)
-      #email-field-panel.panel-indent.util_mb-medium.js-hidden
-        .form-group class=('error' if @form.errors[:email].any?)
-          = f.label :email, class: 'form-label'
-          span.error-message#email = @form.errors[:email].join(' ') if @form.errors[:email].any?
-          = f.text_field :email, class: 'form-control'
-
-      label.block-label data-target="phone-number-panel"
-        = f.check_box :phone_option
-        = t('phone_option', scope: @form.i18n_scope)
-      #phone-number-panel.panel-indent.util_mb-medium.js-hidden
-        .form-group class=('error' if @form.errors[:phone].any?)
-          = f.label :phone, class: 'form-label'
-          span.error-message#phone = @form.errors[:phone].join(' ') if @form.errors[:phone].any?
-          = f.text_field :phone, class: 'form-control'
-
-      label.block-label
-        = f.check_box :post_option
-        = t('post_option', scope: @form.i18n_scope)
+        = t('email_optin', scope: @form.i18n_scope)
 
     .form-group
       = f.submit t('submit_button'), class: 'button'

--- a/app/views/questions/_contact.html.slim
+++ b/app/views/questions/_contact.html.slim
@@ -17,8 +17,8 @@ h2.heading-large
 
     .form-group.text
       label
-        = f.check_box :email_option
-        = t('email_optin', scope: @form.i18n_scope)
+        = f.check_box :feedback_opt_in
+        = t('feedback_opt_in', scope: @form.i18n_scope)
 
     .form-group
       = f.submit t('submit_button'), class: 'button'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -187,4 +187,4 @@ en:
       text: "What's your email address?"
       details: "We can email you to confirm your application has been received."
       email_label: "Email address"
-      email_optin: "Check this box if you're willing to share your experience of this service. A member of the team may contact you. We won't use your email address for anything else."
+      feedback_opt_in: "Check this box if you're willing to share your experience of this service. A member of the team may contact you. We won't use your email address for anything else."

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -184,8 +184,7 @@ en:
       text: 'What is your address?'
     contact:
       breadcrumb: 'Question 14 of 14'
-      text: "What's the best way to contact you?"
-      email_option: "Email"
-      phone_option: "Phone call"
-      post_option: "Post"
-      details: "Enter an email address if you want an email confirmation of your application."
+      text: "What's your email address?"
+      details: "We can email you to confirm your application has been received."
+      email_label: "Email address"
+      email_optin: "Check this box if you're willing to share your experience of this service. A member of the team may contact you. We won't use your email address for anything else."

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -396,7 +396,6 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
     expect(page).to have_content "What's your email address?"
-    check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
   end
@@ -446,7 +445,6 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
     expect(page).to have_content "What's your email address?"
-    check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
     expect(page).to have_content 'Check details'
@@ -513,7 +511,6 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
     expect(page).to have_content "What's your email address?"
-    check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
     expect(page).to have_content 'Check details'

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -395,7 +395,7 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_address', with: 'Foo Street'
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
-    expect(page).to have_content "What's the best way to contact you?"
+    expect(page).to have_content "What's your email address?"
     check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
@@ -445,7 +445,7 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_address', with: 'Foo Street'
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
-    expect(page).to have_content "What's the best way to contact you?"
+    expect(page).to have_content "What's your email address?"
     check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
@@ -512,7 +512,7 @@ RSpec.feature 'As a user' do
     fill_in 'applicant_address_address', with: 'Foo Street'
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
-    expect(page).to have_content "What's the best way to contact you?"
+    expect(page).to have_content "What's your email address?"
     check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'

--- a/spec/features/pages/applicant_address_question_spec.rb
+++ b/spec/features/pages/applicant_address_question_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'As a user' do
       end
 
       scenario 'I expect to be routed to the "fee" page' do
-        expect(page).to have_content "What's the best way to contact you?"
+        expect(page).to have_content "What's your email address?"
       end
     end
 

--- a/spec/features/pages/contact_question_spec.rb
+++ b/spec/features/pages/contact_question_spec.rb
@@ -16,21 +16,6 @@ RSpec.feature 'As a user' do
     end
 
     context 'not completing the page correctly' do
-      context 'selecting phone' do
-        before { check :contact_phone_option }
-
-        describe 'leaving the phone text empty' do
-          before { click_button 'Continue' }
-          scenario 'I expect to be shown the "contact" page with error block' do
-            expect(page).to have_content 'You need to fix the errors on this page before continuing.'
-          end
-
-          scenario 'I expect the fields to have specific errors' do
-            expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter your phone number')
-          end
-        end
-      end
-
       context 'selecting email' do
         before { check :contact_email_option }
 

--- a/spec/features/pages/contact_question_spec.rb
+++ b/spec/features/pages/contact_question_spec.rb
@@ -16,18 +16,18 @@ RSpec.feature 'As a user' do
     end
 
     context 'not completing the page correctly' do
-      context 'selecting email' do
-        before { check :contact_email_option }
+      describe 'entering invalid email text ' do
+        before do
+          fill_in :contact_email, with: 'foobar.com'
+          click_button 'Continue'
+        end
 
-        describe 'leaving the email text empty' do
-          before { click_button 'Continue' }
-          scenario 'I expect to be shown the "contact" page with error block' do
-            expect(page).to have_content 'You need to fix the errors on this page before continuing.'
-          end
+        scenario 'I expect to be shown the "contact" page with error block' do
+          expect(page).to have_content 'You need to fix the errors on this page before continuing.'
+        end
 
-          scenario 'I expect the fields to have specific errors' do
-            expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter a valid email address')
-          end
+        scenario 'I expect the fields to have specific errors' do
+          expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter a valid email address')
         end
       end
     end

--- a/spec/features/pages/summary_spec.rb
+++ b/spec/features/pages/summary_spec.rb
@@ -65,16 +65,11 @@ RSpec.feature 'As a user' do
         visit question_path(:contact)
         check :contact_email_option
         fill_in :contact_email, with: 'foo@bar.com'
-        check :contact_phone_option
-        fill_in :contact_phone, with: '00000 000000'
-        check :contact_post_option
         click_button 'Continue'
       end
 
       scenario 'I expect confirmation ' do
         expect(page).to have_content 'Emailfoo@bar.com'
-        expect(page).to have_content 'Phone00000 000000'
-        expect(page).to have_content 'PostYes'
       end
     end
 

--- a/spec/features/pages/summary_spec.rb
+++ b/spec/features/pages/summary_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'As a user' do
     context 'after answering yes to all of the contact options' do
       before do
         visit question_path(:contact)
-        check :contact_email_option
+        check :contact_feedback_opt_in
         fill_in :contact_email, with: 'foo@bar.com'
         click_button 'Continue'
       end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -2,136 +2,75 @@ require 'rails_helper'
 
 RSpec.describe Contact, type: :model do
   subject do
-    described_class.new(email_option: true,
-                        email: 'foo@bar.com',
-                        phone_option: true,
-                        phone: '078 112 123 22',
-                        post_option: true)
+    described_class.new(email: 'foo@bar.com',
+                        feedback_opt_in: true)
   end
 
   describe 'validations' do
-    describe 'email_option' do
-      context 'when true' do
+    describe 'email' do
+      context 'and valid email is given' do
         it { expect(subject.valid?).to be true }
       end
 
-      context 'when false' do
-        before { subject.email_option = false }
+      context 'and invalid email is given' do
+        before { subject.email = 'foobar.com' }
 
-        it { expect(subject.valid?).to be true }
+        it { expect(subject.valid?).to be false }
       end
 
-      describe 'email' do
-        context 'when email_option is true' do
-          context 'and email is given' do
-            it { expect(subject.valid?).to be true }
-          end
-
-          context 'and email is not given' do
-            before { subject.email = '' }
-
-            it { expect(subject.valid?).to be false }
-          end
-        end
-      end
-    end
-
-    describe 'phone_option' do
-      context 'when true' do
-        it { expect(subject.valid?).to be true }
-      end
-
-      context 'when false' do
-        before { subject.phone_option = false }
-
-        it { expect(subject.valid?).to be true }
-      end
-
-      describe 'phone' do
-        context 'when phone_option is true' do
-          context 'and phone is given' do
-            it { expect(subject.valid?).to be true }
-          end
-
-          context 'and phone is not given' do
-            before { subject.phone = '' }
-
-            it { expect(subject.valid?).to be false }
-          end
-        end
-      end
-    end
-
-    describe 'post_option' do
-      context 'when true' do
-        it { expect(subject.valid?).to be true }
-      end
-
-      context 'when false' do
-        before { subject.post_option = false }
+      context 'and email is not given' do
+        before { subject.email = '' }
 
         it { expect(subject.valid?).to be true }
       end
     end
 
-    describe 'when no option is picked' do
-      # TODO: discuss this
-      before do
-        subject.email_option = false
-        subject.phone_option = false
-        subject.post_option = false
+    describe 'feedback_opt_in' do
+      context 'when true' do
+        it { expect(subject.valid?).to be true }
+      end
+
+      context 'when false' do
+        before { subject.feedback_opt_in = false }
+
+        it { expect(subject.valid?).to be true }
       end
     end
   end
 
   describe '#export' do
-    let(:email_option) { true }
     let(:email) { 'some@email.domain' }
-    let(:phone_option) { true }
-    let(:phone) { '12345678' }
-    let(:post_option) { true }
+    let(:feedback_opt_in) { true }
 
-    subject { described_class.new(email_option: email_option, email: email, phone_option: phone_option, phone: phone, post_option: post_option).export }
+    subject { described_class.new(email: email, feedback_opt_in: feedback_opt_in).export }
 
-    context 'when email_option is true' do
+    context 'when email is set' do
       it 'the returned hash includes email_contact true and email_address' do
         is_expected.to include(email_contact: true, email_address: email)
       end
     end
 
-    context 'when email_option is false' do
-      let(:email_option) { false }
+    context 'when email is not set' do
+      let(:email) { nil }
 
-      it 'the returned hash includes email_contact true and email_address is nil' do
-        is_expected.to include(email_contact: false, email_address: nil)
+      it 'the returned hash includes email_contact false and email_address is nil' do
+        is_expected.to include(email_contact: false, email_address: email)
       end
     end
 
-    context 'when phone_option is true' do
-      it 'the returned hash includes phone_contact true and phone' do
-        is_expected.to include(phone_contact: true, phone: phone)
-      end
+    it 'the returned hash always returns phone_contact as false' do
+      is_expected.to include(phone_contact: false)
     end
 
-    context 'when phone_option is false' do
-      let(:phone_option) { false }
-
-      it 'the returned hash includes phone_contact true and phone is nil' do
-        is_expected.to include(phone_contact: false, phone: nil)
-      end
+    it 'the returned hash includesreturns post_contact as false' do
+      is_expected.to include(post_contact: false)
     end
 
-    context 'when post_option is true' do
-      it 'the returned hash includes post_contact true' do
-        is_expected.to include(post_contact: true)
-      end
-    end
+    context 'when feedback_opt_in is false' do
+      let(:feedback_opt_in) { false }
 
-    context 'when post_option is false' do
-      let(:post_option) { false }
-
-      it 'the returned hash includes post_contact true' do
-        is_expected.to include(post_contact: false)
+      it 'the returned hash includes feedback_opt_in false' do
+        is_expected.to include(feedback_opt_in: false)
       end
     end
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Contact, type: :model do
       is_expected.to include(post_contact: false)
     end
 
+    context 'when feedback_opt_in is true' do
+      it 'the returned hash includes feedback_opt_in true' do
+        is_expected.to include(feedback_opt_in: true)
+      end
+    end
+
     context 'when feedback_opt_in is false' do
       let(:feedback_opt_in) { false }
 

--- a/spec/services/online_application_builder_spec.rb
+++ b/spec/services/online_application_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OnlineApplicationBuilder do
       'personal_detail' => { 'title' => 'Mrs.', 'first_name' => 'Mary', 'last_name' => 'Jones' },
       'dob' => { 'date_of_birth' => '10/03/1967' },
       'applicant_address' => { 'address' => '1 Blue Fields, Shine Town', 'postcode' => 'SH01 TW0' },
-      'contact' => { 'email_option' => true, 'email' => 'mary@jones.com', 'phone_option' => true, 'phone' => '0721323232', 'post_option' => true }
+      'contact' => { 'email_option' => true, 'email' => 'mary@jones.com', 'phone_option' => false, 'post_option' => false, 'feedback_opt_in' => true }
     }
   end
   # We're using the real storage here to avoid an unnecessary mocking as these are mostly value objects
@@ -53,9 +53,9 @@ RSpec.describe OnlineApplicationBuilder do
       expect(subject.postcode).to eql('SH01 TW0')
       expect(subject.email_contact).to be true
       expect(subject.email_address).to eql('mary@jones.com')
-      expect(subject.phone_contact).to be true
-      expect(subject.phone).to eql('0721323232')
-      expect(subject.post_contact).to be true
+      expect(subject.phone_contact).to be false
+      expect(subject.post_contact).to be false
+      expect(subject.feedback_opt_in).to be true
     end
   end
 end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -31,7 +31,6 @@ module FeatureSteps
     fill_in 'applicant_address_address', with: 'Foo Street'
     fill_in 'applicant_address_postcode', with: 'Bar'
     click_button 'Continue'
-    check 'contact_email_option'
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
   end

--- a/tests/nightwatch/commands/startService.js
+++ b/tests/nightwatch/commands/startService.js
@@ -12,7 +12,7 @@ exports.command = function(callback) {
       .deleteCookies()
       .init()
       .maximizeWindow()
-      .ensureCorrectPage('input.button-start', '', {
+      .ensureCorrectPage('.button-start', '', {
         'h1': 'Apply for help with fees'
       })
       .pause(200)

--- a/tests/nightwatch/specs/happypath-test-show-hide.js
+++ b/tests/nightwatch/specs/happypath-test-show-hide.js
@@ -4,7 +4,7 @@ module.exports = {
   'Start': function(client) {
     client
       .startService()
-      .click('input.button-start', function() {
+      .click('.button-start', function() {
         console.log('     * Click start button');
       })
     ;
@@ -89,68 +89,6 @@ module.exports = {
       })
       .testShowHideRadio('claim_number', ['true', 'false'], 'claim-identifier-panel')
       .radioSelect('claim_number', 'false')
-      .nextPage()
-    ;
-  },
-
-  'Form name': function(client) {
-    client
-      .ensureCorrectPage('form.new_form_name', '/form-name', {
-        'h2': 'Question 9 of 14'
-      })
-      .nextPage()
-    ;
-  },
-
-  'NI number': function(client) {
-    client
-      .ensureCorrectPage('form.new_national_insurance', '/national-insurance', {
-        'h2': 'Question 10 of 14'
-      })
-      .setValue('#national_insurance_number', 'AB123456C')
-      .nextPage()
-    ;
-  },
-
-  'Date of birth': function(client) {
-    client
-      .ensureCorrectPage('form.new_dob', '/dob', {
-        'h2': 'Question 11 of 14'
-      })
-      .setValue('#dob_date_of_birth', '01/01/1980')
-      .nextPage()
-    ;
-  },
-
-  'Personal detail': function(client) {
-    client
-      .ensureCorrectPage('form.new_personal_detail', '/personal-detail', {
-        'h2': 'Question 12 of 14'
-      })
-      .setValue('#personal_detail_first_name', 'Test')
-      .setValue('#personal_detail_last_name', 'Tester')
-      .nextPage()
-    ;
-  },
-
-  'Address': function(client) {
-    client
-      .ensureCorrectPage('form.new_applicant_address', '/applicant-address', {
-        'h2': 'Question 13 of 14'
-      })
-      .setValue('#applicant_address_address', '1 Test Street')
-      .setValue('#applicant_address_postcode', 'TE37 1NG')
-      .nextPage()
-    ;
-  },
-
-  'Contact': function(client) {
-    client
-      .ensureCorrectPage('form.new_contact', '/contact', {
-        'h2': 'Question 14 of 14'
-      })
-      .testShowHideCheckbox('contact_email_option', 'email-field-panel')
-      .testShowHideCheckbox('contact_phone_option', 'phone-number-panel')
     ;
   },
 

--- a/tests/nightwatch/specs/income-table.js
+++ b/tests/nightwatch/specs/income-table.js
@@ -4,7 +4,7 @@ module.exports = {
   'Start': function(client) {
     client
       .startService()
-      .click('input.button-start', function() {
+      .click('.button-start', function() {
         console.log('     * Click start button');
       })
     ;


### PR DESCRIPTION
Contact page now only has one field - email - which should be optional, plus a "I can be contacted for research purposes" opt-in checkbox.

[See the corresponding page in the prototype](http://ministryofjustice.github.io/fr-prototypes/public/journey-7/contact.html).

Before
---
![screen shot 2016-03-15 at 14 03 56](https://cloud.githubusercontent.com/assets/988436/13780305/c91e16d8-eab6-11e5-9f77-cb424322d33f.png)

After
---
![screen shot 2016-03-15 at 14 04 23](https://cloud.githubusercontent.com/assets/988436/13780323/d66512c4-eab6-11e5-928e-1a9a714aa4b5.png)

Back-end work required
===
* I've visually repurposed the existing email checkbox from the old version. This may or may not need renaming - I assume something will need doing here so that the app records the opt-in value
* The validation on here is from the old version, so it doesn't work correctly i.e. if you check the box, and fill in a malformed email address, the validation triggers *but* if you don't check the box, the validation doesn't trigger (because in the old version the email address field would be hidden and ignored.
* The 'check details' page needs to be updated, as it's expecting the old contact details from the old version. It should show the email address if one was entered, and possibly a boolean value corresponding to the opt-in checkbox