### PR TITLE
external links in new window

### DIFF
--- a/app/assets/javascripts/modules/external-links.js
+++ b/app/assets/javascripts/modules/external-links.js
@@ -1,0 +1,7 @@
+'use strict';
+
+window.moj.Modules.ExternalLinks = {
+  init: function() {
+    $('a[rel="external"]').attr('target', '_blank');
+  }
+};

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -27,7 +27,7 @@ ul.list.list-bullet
   li your court fee is more than £1,000
   li you earn more than £1,085 a month (before tax and National Insurance is taken off) and you have financially dependent children
 
-p See the #{link_to 'guide', 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-20160212.pdf'} for detailed information about who is eligible to apply for help with fees.
+p See the #{link_to 'guide', 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160a-eng-20160212.pdf', class: "external", rel: "external"} for detailed information about who is eligible to apply for help with fees.
 
 h2.heading-large What you'll need:
 ul.list.list-bullet


### PR DESCRIPTION
The gov.uk template CSS adds a new window icon to any links with `rel="external"`, so this line of jQuery adds the HTML attribute `target="_blank"` so that they actually do open in a new window/tab.
