### PR TITLE
New copy for refund confirmation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,6 @@ end
 group :test do
   gem 'capybara'
   gem 'codeclimate-test-reporter', require: nil
+  gem 'timecop'
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -293,6 +294,7 @@ DEPENDENCIES
   sass-rails (= 5.0.4)
   slim-rails
   spring
+  timecop
   uglifier (>= 1.3.0)
   unicorn
   virtus

--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -5,7 +5,7 @@
   li {
     margin-bottom: 1.5em;
 
-    .number {
+    .inset {
       display: table;
       background-color: $grey-4;
       border: 1px solid $grey-2;

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -12,6 +12,7 @@ class SubmissionsController < ApplicationController
   end
 
   def show
+    @online_application = builder.online_application
     @result = storage.submission_result
     reset_session
   end

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -26,4 +26,8 @@ class OnlineApplication
   attribute :phone, String
   attribute :post_contact, Boolean
   attribute :feedback_opt_in, Boolean
+
+  def full_name
+    %i[title first_name last_name].map { |field| send(field) }.compact.join(' ')
+  end
 end

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -1,6 +1,7 @@
 - content_for :stylesheets
   = stylesheet_link_tag('confirmation-print.css', media: 'print')
 
+/ IF CONFIRMATION
 h2.heading-large
   span.heading-secondary =t('confirmation.breadcrumb')
   =t('confirmation.heading')
@@ -8,7 +9,7 @@ h2.heading-large
 ol.list.list-number.next-steps
   li
     =t('confirmation.steps.one')
-    .number =@result['message']
+    .inset =@result['message']
   li =t('confirmation.steps.two')
   li =t('confirmation.steps.three')
   li =t('confirmation.steps.four')
@@ -19,5 +20,35 @@ ol.list.list-number.next-steps
       span.visuallyhidden =t('confirmation.notice.warning')
     strong.bold-small =t('confirmation.notice.text')
 
+
+/ ELSE IF REFUND
+h2.heading-large
+  span.heading-secondary =t('confirmation.breadcrumb')
+  =t('refund.heading')
+
+ol.list.list-number.next-steps
+  li
+    ul
+      li =t('refund.steps.one.one')
+      li
+        =t('refund.steps.one.two')
+        .inset
+          ul
+            li =t('refund.letter.one')
+            li =t('refund.letter.two')
+            li =t('refund.letter.three')
+            li =t('refund.letter.four')
+            li =t('refund.letter.five')
+  li =t('refund.steps.two')
+  li =t('refund.steps.three')
+
+.notice
+  h3.heading-medium
+    i.icon.icon-important
+      span.visuallyhidden =t('refund.notice.warning')
+    strong.bold-small =t('refund.notice.text')
+
+
+/ SHOW IN BOTH CASES
 .js-only
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -1,54 +1,50 @@
 - content_for :stylesheets
   = stylesheet_link_tag('confirmation-print.css', media: 'print')
 
-/ IF CONFIRMATION
-h2.heading-large
-  span.heading-secondary =t('confirmation.breadcrumb')
-  =t('confirmation.heading')
+- if @online_application.refund?
+  h2.heading-large
+    span.heading-secondary = t('confirmation.breadcrumb')
+    = t('refund.heading')
 
-ol.list.list-number.next-steps
-  li
-    =t('confirmation.steps.one')
-    .inset =@result['message']
-  li =t('confirmation.steps.two')
-  li =t('confirmation.steps.three')
-  li =t('confirmation.steps.four')
+  ol.list.list-number.next-steps
+    li
+      ul
+        li = t('refund.steps.one.one')
+        li
+          = t('refund.steps.one.two')
+          .inset
+            ul
+              li = t('refund.letter.one', reference: @result['message'])
+              li = t('refund.letter.two')
+              li = t('refund.letter.three', date_fee_paid: @online_application.date_fee_paid)
+              li = t('refund.letter.four')
+              li = t('refund.letter.five', full_name: @online_application.full_name)
+    li = t('refund.steps.two')
+    li = t('refund.steps.three')
 
-.notice
-  h3.heading-medium
-    i.icon.icon-important
-      span.visuallyhidden =t('confirmation.notice.warning')
-    strong.bold-small =t('confirmation.notice.text')
+  .notice
+    h3.heading-medium
+      i.icon.icon-important
+        span.visuallyhidden = t('refund.notice.warning')
+      strong.bold-small = t('refund.notice.text')
+- else
+  h2.heading-large
+    span.heading-secondary =t('confirmation.breadcrumb')
+    =t('confirmation.heading')
 
+  ol.list.list-number.next-steps
+    li
+      =t('confirmation.steps.one')
+      .inset =@result['message']
+    li =t('confirmation.steps.two')
+    li =t('confirmation.steps.three')
+    li =t('confirmation.steps.four')
 
-/ ELSE IF REFUND
-h2.heading-large
-  span.heading-secondary =t('confirmation.breadcrumb')
-  =t('refund.heading')
+  .notice
+    h3.heading-medium
+      i.icon.icon-important
+        span.visuallyhidden =t('confirmation.notice.warning')
+      strong.bold-small =t('confirmation.notice.text')
 
-ol.list.list-number.next-steps
-  li
-    ul
-      li =t('refund.steps.one.one')
-      li
-        =t('refund.steps.one.two')
-        .inset
-          ul
-            li =t('refund.letter.one')
-            li =t('refund.letter.two')
-            li =t('refund.letter.three')
-            li =t('refund.letter.four')
-            li =t('refund.letter.five')
-  li =t('refund.steps.two')
-  li =t('refund.steps.three')
-
-.notice
-  h3.heading-medium
-    i.icon.icon-important
-      span.visuallyhidden =t('refund.notice.warning')
-    strong.bold-small =t('refund.notice.text')
-
-
-/ SHOW IN BOTH CASES
 .js-only
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')

--- a/config/locales/en_confirmation.yml
+++ b/config/locales/en_confirmation.yml
@@ -11,3 +11,20 @@ en:
       warning: Warning
       text: Your case will not proceed until you send your claim form to the court or tribunal
     print: Print this page
+  refund:
+    heading: Send your reference number to the court or tribunal dealing with your case
+    steps:
+      one:
+        one: Deliver your reference number to the court or tribunal dealing with your case (by post or in person)
+        two: 'You can use the letter template below:'
+      two: Your application will be assessed by court or tribunal staff
+      three: You'll hear from the court or tribunal if your application is unsuccessful or if they need more information from you
+    letter:
+      one: 'Reference: XXXXX-XX-X'
+      two: I have completed an online application for help with fees for a refund.
+      three: I paid the fee of £XX on XX/XX/201X.
+      four: Yours sincerely,
+      five: Mr Mark Morgan
+    notice:
+      warning: Warning
+      text: Your application for a refund will not proceed until you send your reference number to the court or tribunal

--- a/config/locales/en_confirmation.yml
+++ b/config/locales/en_confirmation.yml
@@ -20,11 +20,11 @@ en:
       two: Your application will be assessed by court or tribunal staff
       three: You'll hear from the court or tribunal if your application is unsuccessful or if they need more information from you
     letter:
-      one: 'Reference: XXXXX-XX-X'
+      one: 'Reference: %{reference}'
       two: I have completed an online application for help with fees for a refund.
-      three: I paid the fee of £XX on XX/XX/201X.
+      three: I paid a fee on %{date_fee_paid}.
       four: Yours sincerely,
-      five: Mr Mark Morgan
+      five: '%{full_name}'
     notice:
       warning: Warning
       text: Your application for a refund will not proceed until you send your reference number to the court or tribunal

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 RSpec.describe SubmissionsController, type: :controller do
   let(:session) { double }
   let(:storage) { double }
+  let(:online_application) { double }
+  let(:builder) { double(online_application: online_application) }
 
   before do
     allow(controller).to receive(:session).and_return(session)
     allow(Storage).to receive(:new).with(session).and_return(storage)
+    allow(OnlineApplicationBuilder).to receive(:new).with(storage).and_return(builder)
   end
 
   describe 'POST #create' do
-    let(:online_application) { double }
-    let(:builder) { double(online_application: online_application) }
     let(:service) { double }
 
     before do
-      allow(OnlineApplicationBuilder).to receive(:new).with(storage).and_return(builder)
       allow(SubmitApplication).to receive(:new).and_return(service)
       allow(service).to receive(:post).with(online_application).and_return(response)
       allow(storage).to receive(:submission_result=)
@@ -72,6 +72,10 @@ RSpec.describe SubmissionsController, type: :controller do
 
     it 'clears the session' do
       expect(controller).to have_received(:reset_session)
+    end
+
+    it 'assigns the online application model' do
+      expect(assigns(:online_application)).to eql(online_application)
     end
   end
 end

--- a/spec/features/user_submits_their_application_spec.rb
+++ b/spec/features/user_submits_their_application_spec.rb
@@ -3,11 +3,18 @@ require 'rails_helper'
 RSpec.feature 'User submits their application' do
   let(:reference) { 'HWF-CIDI16' }
 
-  scenario 'User submits their application and it is successfully processed' do
+  scenario 'User submits their non refund application and it is successfully processed' do
     given_user_provides_all_data
     and_the_submission_service_is_available(reference)
     when_they_submit_the_application
-    then_they_are_presented_with_the_confirmation_page_with_reference_number
+    then_they_are_presented_with_the_non_refund_confirmation_page_with_reference_number
+  end
+
+  scenario 'User submits their refund application and it is successfully processed' do
+    given_user_provides_all_data_for_refund
+    and_the_submission_service_is_available(reference)
+    when_they_submit_the_application
+    then_they_are_presented_with_the_refund_confirmation_page_with_reference_number
   end
 
   scenario 'User submits their application, but it is not processed' do
@@ -17,9 +24,17 @@ RSpec.feature 'User submits their application' do
     then_they_are_redirected_to_the_summary_page_with_error_message
   end
 
-  def then_they_are_presented_with_the_confirmation_page_with_reference_number
+  def then_they_are_presented_with_the_non_refund_confirmation_page_with_reference_number
     expect(page.current_path).to eql('/submission')
     expect(page).to have_content(reference)
+    expect(page).to have_content('Send your claim form to the court or tribunal dealing with your case')
+  end
+
+  def then_they_are_presented_with_the_refund_confirmation_page_with_reference_number
+    expect(page.current_path).to eql('/submission')
+    expect(page).to have_content('Send your reference number to the court or tribunal dealing with your case')
+    expect(page).to have_content(reference)
+    expect(page).to have_content('Sir Bob Oliver')
   end
 
   def then_they_are_redirected_to_the_summary_page_with_error_message

--- a/spec/features/user_submits_their_application_spec.rb
+++ b/spec/features/user_submits_their_application_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'User submits their application' do
+  let(:current_time) { Time.zone.parse('2016-03-29 14:50') }
   let(:reference) { 'HWF-CIDI16' }
 
   scenario 'User submits their non refund application and it is successfully processed' do
@@ -11,7 +12,9 @@ RSpec.feature 'User submits their application' do
   end
 
   scenario 'User submits their refund application and it is successfully processed' do
-    given_user_provides_all_data_for_refund
+    Timecop.freeze(current_time) do
+      given_user_provides_all_data_for_refund
+    end
     and_the_submission_service_is_available(reference)
     when_they_submit_the_application
     then_they_are_presented_with_the_refund_confirmation_page_with_reference_number
@@ -34,6 +37,7 @@ RSpec.feature 'User submits their application' do
     expect(page.current_path).to eql('/submission')
     expect(page).to have_content('Send your reference number to the court or tribunal dealing with your case')
     expect(page).to have_content(reference)
+    expect(page).to have_content('on 08/03/2016')
     expect(page).to have_content('Sir Bob Oliver')
   end
 

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe OnlineApplication, type: :model do
+  describe '#full_name' do
+    subject(:model) { build(:online_application, title: title) }
+    subject { model.full_name }
+
+    context 'when title is set' do
+      let(:title) { 'Title' }
+
+      it 'contains title, first name and last name' do
+        is_expected.to eql("#{title} #{model.first_name} #{model.last_name}")
+      end
+    end
+
+    context 'when title is not set' do
+      let(:title) { nil }
+
+      it 'contains only first name and last name' do
+        is_expected.to eql("#{model.first_name} #{model.last_name}")
+      end
+    end
+  end
+end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -35,6 +35,43 @@ module FeatureSteps
     click_button 'Continue'
   end
 
+  def given_user_provides_all_data_for_refund
+    visit '/'
+    click_link_or_button 'Apply now'
+    choose 'marital_status_married_false'
+    click_button 'Continue'
+    choose 'savings_and_investment_less_than_limit_false'
+    click_button 'Continue'
+    choose 'benefit_on_benefits_false'
+    click_button 'Continue'
+    choose 'dependent_children_false'
+    click_button 'Continue'
+    fill_in :income_wages, with: 100.0
+    click_button 'Continue'
+    choose 'fee_paid_true'
+    fill_in :fee_date_paid, with: 3.weeks.ago
+    click_button 'Continue'
+    choose 'probate_kase_false'
+    click_button 'Continue'
+    choose 'claim_number_false'
+    click_button 'Continue'
+    fill_in 'form_name_identifier', with: 'N1'
+    click_button 'Continue'
+    fill_in 'national_insurance_number', with: 'AB123456A'
+    click_button 'Continue'
+    fill_in 'dob_date_of_birth', with: '01/01/1980'
+    click_button 'Continue'
+    fill_in 'personal_detail_title', with: 'Sir'
+    fill_in 'personal_detail_first_name', with: 'Bob'
+    fill_in 'personal_detail_last_name', with: 'Oliver'
+    click_button 'Continue'
+    fill_in 'applicant_address_address', with: 'Foo Street'
+    fill_in 'applicant_address_postcode', with: 'Bar'
+    click_button 'Continue'
+    fill_in 'contact_email', with: 'foo@bar.com'
+    click_button 'Continue'
+  end
+
   def given_user_starts_an_application
     visit '/'
     click_link_or_button 'Apply now'

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -1,82 +1,47 @@
+# rubocop:disable ModuleLength
 module FeatureSteps
   def given_user_provides_all_data
     visit '/'
     click_link_or_button 'Apply now'
-    choose 'marital_status_married_false'
-    click_button 'Continue'
-    choose 'savings_and_investment_less_than_limit_false'
-    click_button 'Continue'
-    choose 'benefit_on_benefits_false'
-    click_button 'Continue'
-    choose 'dependent_children_false'
-    click_button 'Continue'
-    fill_in :income_wages, with: 100.0
-    click_button 'Continue'
-    choose 'fee_paid_false'
-    click_button 'Continue'
-    choose 'probate_kase_false'
-    click_button 'Continue'
-    choose 'claim_number_false'
-    click_button 'Continue'
-    fill_in 'form_name_identifier', with: 'N1'
-    click_button 'Continue'
-    fill_in 'national_insurance_number', with: 'AB123456A'
-    click_button 'Continue'
-    fill_in 'dob_date_of_birth', with: '01/01/1980'
-    click_button 'Continue'
-    fill_in 'personal_detail_title', with: 'Sir'
-    fill_in 'personal_detail_first_name', with: 'Bob'
-    fill_in 'personal_detail_last_name', with: 'Oliver'
-    click_button 'Continue'
-    fill_in 'applicant_address_address', with: 'Foo Street'
-    fill_in 'applicant_address_postcode', with: 'Bar'
-    click_button 'Continue'
-    fill_in 'contact_email', with: 'foo@bar.com'
-    click_button 'Continue'
+    fill_marital_status
+    fill_savings_and_investment
+    fill_benefit
+    fill_dependent
+    fill_income
+    fill_fee
+    fill_probate
+    fill_claim
+    fill_form_name
+    fill_national_insurance
+    fill_dob
+    fill_personal_detail
+    fill_applicant_address
+    fill_contact
   end
 
   def given_user_provides_all_data_for_refund
     visit '/'
     click_link_or_button 'Apply now'
-    choose 'marital_status_married_false'
-    click_button 'Continue'
-    choose 'savings_and_investment_less_than_limit_false'
-    click_button 'Continue'
-    choose 'benefit_on_benefits_false'
-    click_button 'Continue'
-    choose 'dependent_children_false'
-    click_button 'Continue'
-    fill_in :income_wages, with: 100.0
-    click_button 'Continue'
-    choose 'fee_paid_true'
-    fill_in :fee_date_paid, with: 3.weeks.ago
-    click_button 'Continue'
-    choose 'probate_kase_false'
-    click_button 'Continue'
-    choose 'claim_number_false'
-    click_button 'Continue'
-    fill_in 'form_name_identifier', with: 'N1'
-    click_button 'Continue'
-    fill_in 'national_insurance_number', with: 'AB123456A'
-    click_button 'Continue'
-    fill_in 'dob_date_of_birth', with: '01/01/1980'
-    click_button 'Continue'
-    fill_in 'personal_detail_title', with: 'Sir'
-    fill_in 'personal_detail_first_name', with: 'Bob'
-    fill_in 'personal_detail_last_name', with: 'Oliver'
-    click_button 'Continue'
-    fill_in 'applicant_address_address', with: 'Foo Street'
-    fill_in 'applicant_address_postcode', with: 'Bar'
-    click_button 'Continue'
-    fill_in 'contact_email', with: 'foo@bar.com'
-    click_button 'Continue'
+    fill_marital_status
+    fill_savings_and_investment
+    fill_benefit
+    fill_dependent
+    fill_income
+    fill_fee(true)
+    fill_probate
+    fill_claim
+    fill_form_name
+    fill_national_insurance
+    fill_dob
+    fill_personal_detail
+    fill_applicant_address
+    fill_contact
   end
 
   def given_user_starts_an_application
     visit '/'
     click_link_or_button 'Apply now'
-    choose 'marital_status_married_false'
-    click_button 'Continue'
+    fill_marital_status
   end
 
   def when_they_submit_the_application
@@ -92,6 +57,85 @@ module FeatureSteps
     visit question_path(:marital_status)
     expect(page).to have_unchecked_field('marital_status_married_false')
     expect(page).to have_unchecked_field('marital_status_married_true')
+  end
+
+  def fill_contact
+    fill_in 'contact_email', with: 'foo@bar.com'
+    click_button 'Continue'
+  end
+
+  def fill_applicant_address
+    fill_in 'applicant_address_address', with: 'Foo Street'
+    fill_in 'applicant_address_postcode', with: 'Bar'
+    click_button 'Continue'
+  end
+
+  def fill_personal_detail
+    fill_in 'personal_detail_title', with: 'Sir'
+    fill_in 'personal_detail_first_name', with: 'Bob'
+    fill_in 'personal_detail_last_name', with: 'Oliver'
+    click_button 'Continue'
+  end
+
+  def fill_dob
+    fill_in 'dob_date_of_birth', with: '01/01/1980'
+    click_button 'Continue'
+  end
+
+  def fill_national_insurance
+    fill_in 'national_insurance_number', with: 'AB123456A'
+    click_button 'Continue'
+  end
+
+  def fill_form_name
+    fill_in 'form_name_identifier', with: 'N1'
+    click_button 'Continue'
+  end
+
+  def fill_claim
+    choose 'claim_number_false'
+    click_button 'Continue'
+  end
+
+  def fill_probate
+    choose 'probate_kase_false'
+    click_button 'Continue'
+  end
+
+  def fill_fee(refund = false)
+    if refund
+      choose 'fee_paid_true'
+      fill_in :fee_date_paid, with: 3.weeks.ago
+    else
+      choose 'fee_paid_false'
+    end
+
+    click_button 'Continue'
+  end
+
+  def fill_income
+    fill_in :income_wages, with: 100.0
+    click_button 'Continue'
+  end
+
+  def fill_dependent
+    choose 'dependent_children_false'
+    click_button 'Continue'
+  end
+
+  def fill_benefit
+    choose 'benefit_on_benefits_false'
+    click_button 'Continue'
+  end
+
+  def fill_savings_and_investment
+    choose 'savings_and_investment_less_than_limit_false'
+    click_button 'Continue'
+  end
+
+  def fill_marital_status
+    choose 'marital_status_married_false'
+    click_button 'Continue'
   end
 end
 


### PR DESCRIPTION
Different confirmation page depending on whether the application is a refund or not.

Refund version should look like it does [in the prototype](http://ministryofjustice.github.io/fr-prototypes/public/journey-7/confirmation-refund.html).