### PR TITLE
Turn off autocomplete

### DIFF
--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -40,6 +40,10 @@ class Base
     export_params
   end
 
+  def autocomplete
+    Rails.env.development? ? 'on' : 'off'
+  end
+
   private
 
   def export_params

--- a/app/views/questions/_applicant_address.html.slim
+++ b/app/views/questions/_applicant_address.html.slim
@@ -3,7 +3,7 @@ h2.heading-large
   span.heading-secondary= t('breadcrumb', scope: @form.i18n_scope)
   = t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
 

--- a/app/views/questions/_benefit.html.slim
+++ b/app/views/questions/_benefit.html.slim
@@ -26,7 +26,7 @@ ul.list.list-bullet
     span.hint &nbsp; #{t('hint', scope: "#{@form.i18n_scope}.list.item_6")}
 
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors.any?)

--- a/app/views/questions/_claim.html.slim
+++ b/app/views/questions/_claim.html.slim
@@ -6,7 +6,7 @@ h2.heading-large
 p
   =t('subtext', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('hidden_legend', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors[:number].any?)

--- a/app/views/questions/_contact.html.slim
+++ b/app/views/questions/_contact.html.slim
@@ -3,7 +3,7 @@ h2.heading-large
   span.heading-secondary = t('breadcrumb', scope: @form.i18n_scope)
   = t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     

--- a/app/views/questions/_dependent.html.slim
+++ b/app/views/questions/_dependent.html.slim
@@ -4,7 +4,7 @@ h2.heading-large
   span.heading-secondary = t('breadcrumb', scope: @form.i18n_scope)
   = t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors[:children].any?)

--- a/app/views/questions/_dob.html.slim
+++ b/app/views/questions/_dob.html.slim
@@ -3,7 +3,7 @@ h2.heading-large
   span.heading-secondary = t('breadcrumb', scope: @form.i18n_scope)
   = t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden =t('text', scope: @form.i18n_scope)
     .form-group  class=('error' if @form.errors.any?)

--- a/app/views/questions/_fee.html.slim
+++ b/app/views/questions/_fee.html.slim
@@ -5,7 +5,7 @@ h2.heading-large
   = t('text', scope: @form.i18n_scope)
 p = t('details', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors[:paid].any?)

--- a/app/views/questions/_form_name.html.slim
+++ b/app/views/questions/_form_name.html.slim
@@ -6,7 +6,7 @@ h2.heading-large
 p =t('example', scope: @form.i18n_scope)
 
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden =t('text', scope: @form.i18n_scope)
     .form-group  class=('error' if @form.errors.any?)

--- a/app/views/questions/_income.html.slim
+++ b/app/views/questions/_income.html.slim
@@ -9,7 +9,7 @@ p =t('details.section_2', scope: @form.i18n_scope)
 p =t('details.section_3', scope: @form.i18n_scope).html_safe
 p =t('details.section_4', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
 

--- a/app/views/questions/_marital_status.html.slim
+++ b/app/views/questions/_marital_status.html.slim
@@ -4,7 +4,7 @@ h2.heading-large
   span.heading-secondary =t('breadcrumb', scope: @form.i18n_scope)
   =t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden =t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors.any?)

--- a/app/views/questions/_national_insurance.html.slim
+++ b/app/views/questions/_national_insurance.html.slim
@@ -5,7 +5,7 @@ h2.heading-large
 
 p =t('example', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden =t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors.any?)

--- a/app/views/questions/_personal_detail.html.slim
+++ b/app/views/questions/_personal_detail.html.slim
@@ -3,7 +3,7 @@ h2.heading-large
   span.heading-secondary = t('breadcrumb', scope: @form.i18n_scope)
   = t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     .form-group

--- a/app/views/questions/_probate.html.slim
+++ b/app/views/questions/_probate.html.slim
@@ -6,7 +6,7 @@ h2.heading-large
 
 p = t('details', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden= t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors[:kase].any?)

--- a/app/views/questions/_savings_and_investment.html.slim
+++ b/app/views/questions/_savings_and_investment.html.slim
@@ -4,7 +4,7 @@ h2.heading-large
   span.heading-secondary =t('breadcrumb', scope: @form.i18n_scope)
   =t('text', scope: @form.i18n_scope)
 
-= form_for @form, url: question_path(@form), method: :put do |f|
+= form_for @form, url: question_path(@form), html: { autocomplete: @form.autocomplete, method: :put } do |f|
   fieldset
     legend.visuallyhidden = t('text', scope: @form.i18n_scope)
     .form-group class=('error' if @form.errors.any?)

--- a/spec/models/base_spec.rb
+++ b/spec/models/base_spec.rb
@@ -51,4 +51,26 @@ RSpec.describe Base, type: :model do
       expect(subject.export).to eql(params)
     end
   end
+
+  describe '#autocomplete' do
+    before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(env)) }
+
+    describe 'when in the development environment' do
+      let(:env) { 'development' }
+
+      it 'returns `yes`' do
+        expect(subject.autocomplete).to eql 'on'
+      end
+    end
+
+    %w[production test].each do |environment|
+      describe "when in the #{environment} environment" do
+        let(:env) { environment }
+
+        it 'returns `no`' do
+          expect(subject.autocomplete).to eql 'off'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Turns off autocomplete for each of the questions in non-dev environments.

That was an optional thing, but simple to remove if unnecessary!

Unfortunately it seems that browsers remember you choices even if you turn this off. :/