### PR TITLE
add back to start button to confirmation page

### DIFF
--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -48,3 +48,5 @@
 
 .js-only
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')
+
+p.util_mt-large =link_to(t('confirmation.back_to_start'), root_path, class: 'button')

--- a/config/locales/en_confirmation.yml
+++ b/config/locales/en_confirmation.yml
@@ -11,6 +11,7 @@ en:
       warning: Warning
       text: Your case will not proceed until you send your claim form to the court or tribunal
     print: Print this page
+    back_to_start: Back to start
   refund:
     heading: Send your reference number to the court or tribunal dealing with your case
     steps:


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/116519385)

A back to start button, on the confirmation page.

![screen shot 2016-03-29 at 15 57 58](https://cloud.githubusercontent.com/assets/988436/14112558/07395e80-f5c7-11e5-9538-617b9f8fcbd3.png)

NB: links to `root_path`, which works fine locally and probably on demo/staging envs, but will probably need to do something different when it goes properly live. I think?