### PR TITLE
Updated codeclimate engines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,25 @@
 engines:
   fixme:
     enabled: false
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: true
+  eslint:
+    enabled: false
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        ruby:
+          mass_threshold: 30
+ratings:
+  paths:
+  - app/**
+  - lib/**
+  - "**.rb"
+exclude_paths:
+- spec/**/*
+- "**/vendor/**/*"


### PR DESCRIPTION
By disabling a single engine, we seem to have turned off all checks!

This enables the default engines, but still disables the fixme check.