### PR TITLE
fix print stylesheet oddness

### DIFF
--- a/app/assets/stylesheets/confirmation-print.scss
+++ b/app/assets/stylesheets/confirmation-print.scss
@@ -1,6 +1,6 @@
 #global-header-bar,
 .phase-banner,
-.js-print,
+.no-print,
 .heading-secondary {
   display: none;
 }

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -35,7 +35,7 @@
   ol.list.list-number.next-steps
     li
       =t('confirmation.steps.one')
-      .inset =@result['message']
+      .inset.number =@result['message']
     li =t('confirmation.steps.two')
     li =t('confirmation.steps.three')
     li =t('confirmation.steps.four')
@@ -46,7 +46,7 @@
         span.visuallyhidden =t('confirmation.notice.warning')
       strong.bold-small =t('confirmation.notice.text')
 
-.js-only
+.js-only.no-print
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')
 
-p.util_mt-large =link_to(t('confirmation.back_to_start'), root_path, class: 'button')
+p.util_mt-large.no-print =link_to(t('confirmation.back_to_start'), root_path, class: 'button')


### PR DESCRIPTION
I think some bits of the print stylesheet PR got reverted in a merge conflict, or something.

Anyway, this fixes the print stylesheet. Checked and verified :+1: in latest Chrome and Firefox plus IE8, 9 and 10.

