### PR TITLE
Add ability to restart application

### DIFF
--- a/app/assets/stylesheets/local/buttons.scss
+++ b/app/assets/stylesheets/local/buttons.scss
@@ -26,3 +26,21 @@
     background-size: 30px 19px;
   }
 }
+
+.restart-application {
+  @include core-19;
+  border: none;
+  background-color: transparent;
+  color: $link-colour;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < ApplicationController
+  def destroy
+    reset_session
+    redirect_to(root_path)
+  end
+end

--- a/app/views/home/summary.html.slim
+++ b/app/views/home/summary.html.slim
@@ -82,3 +82,5 @@ p =t('statement', scope: 'summary.truth')
 
 = form_tag(submission_path, method: :post) do
   = submit_tag(t('button', scope: 'summary.truth'), class: 'button', role: 'button')
+
+=render('shared/restart_application_link')

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -13,3 +13,5 @@ h2.heading-large
 
     .form-group
       = f.submit t('submit_button'), class: 'button'
+
+=render('shared/restart_application_link')

--- a/app/views/shared/_restart_application_link.html.slim
+++ b/app/views/shared/_restart_application_link.html.slim
@@ -1,0 +1,2 @@
+= form_tag(session_path, method: :delete) do
+  = submit_tag(t('restart_application'))

--- a/app/views/shared/_restart_application_link.html.slim
+++ b/app/views/shared/_restart_application_link.html.slim
@@ -1,2 +1,2 @@
 = form_tag(session_path, method: :delete) do
-  = submit_tag(t('restart_application'))
+  = submit_tag(t('restart_application'), class: 'restart-application')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   start_application: Apply now
+  restart_application: Start a new application
   submit_button: Continue
   error_block:
     heading: 'You need to fix the errors on this page before continuing.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
   resource :submission, only: [:create, :show]
 
   resources :questions, only: [:edit, :update], path_names: { edit: '' }
+
+  resource :session, only: :destroy
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  describe 'DELETE #destroy' do
+    before do
+      allow(controller).to receive(:reset_session)
+
+      delete :destroy
+    end
+
+    it 'clears the session' do
+      expect(controller).to have_received(:reset_session)
+    end
+
+    it 'redirects to the start page' do
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/features/user_can_restart_application_spec.rb
+++ b/spec/features/user_can_restart_application_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature 'User can restart application' do
+
+  scenario 'User decides to abandon application while filling up questions' do
+    given_user_fills_in_few_questions
+    when_they_restart_the_application
+    then_their_data_is_deleted
+  end
+
+  scenario 'User decides to abandon application on the summary page' do
+    given_user_provides_all_data
+    when_they_restart_the_application
+    then_their_data_is_deleted
+  end
+
+end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -44,6 +44,14 @@ module FeatureSteps
     fill_marital_status
   end
 
+  def given_user_fills_in_few_questions
+    visit '/'
+    click_link_or_button 'Apply now'
+    fill_marital_status
+    fill_savings_and_investment
+    fill_benefit
+  end
+
   def when_they_submit_the_application
     click_link_or_button 'Complete application'
   end
@@ -53,11 +61,16 @@ module FeatureSteps
     click_link_or_button 'Apply now'
   end
 
+  def when_they_restart_the_application
+    click_link_or_button 'Start a new application'
+  end
+
   def then_their_data_is_not_persisted
     visit question_path(:marital_status)
     expect(page).to have_unchecked_field('marital_status_married_false')
     expect(page).to have_unchecked_field('marital_status_married_true')
   end
+  alias then_their_data_is_deleted then_their_data_is_not_persisted
 
   def fill_contact
     fill_in 'contact_email', with: 'foo@bar.com'


### PR DESCRIPTION
All question pages and the summary page get `Start a new application` link (button) at the bottom, which clears the session and redirects to the home page.

The form is in a single partial `app/views/shared/_restart_application_link.html.slim`.