### PR TITLE
Return 0 income instead of nil

### DIFF
--- a/app/models/forms/income.rb
+++ b/app/models/forms/income.rb
@@ -45,7 +45,7 @@ module Forms
     def export_params
       usable = attributes.select { |_, v| v.is_a?(Float) }.values
       {
-        income: usable.empty? ? nil : usable.inject(:+)
+        income: usable.empty? ? 0 : usable.inject(:+)
       }
     end
   end

--- a/spec/models/forms/income_spec.rb
+++ b/spec/models/forms/income_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Forms::Income, type: :model do
       let(:other) { nil }
       let(:partner_universal_credit) { nil }
 
-      it 'returns hash with income nil' do
-        is_expected.to eql(income: nil)
+      it 'returns hash with income 0' do
+        is_expected.to eql(income: 0)
       end
     end
 


### PR DESCRIPTION
This is for a case when the user doesn't provide any specific income.
But because the UI still displays 0 as a sum, we can affort to do this
temporarily to fix a bug on income calculation (fr-staffapp).