### PR TITLE
remove duplicate disclaimer heading

### DIFF
--- a/config/locales/en_terms.yml
+++ b/config/locales/en_terms.yml
@@ -2,7 +2,7 @@ en:
   terms:
     heading: 'Terms and conditions'
     sections:
-    - title: 'Disclaimer'
+    - title:
       parts:
       - p: 'By using this ‘apply for help with fees’ service you agree to our privacy policy and to these terms and conditions. Read them carefully.'
     - title: 'General terms and conditions'


### PR DESCRIPTION
Due to a copy/paste artefact there was a disclaimer at the beginning and end of the page

After checking with @leighmoney, removed heading from the top of the page.