### PR TITLE
Add timing to Google analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,4 +26,8 @@ class ApplicationController < ActionController::Base
   def redirect_if_storage_unstarted
     redirect_to(root_path) unless storage.started?
   end
+
+  def ga_events
+    @ga_events ||= []
+  end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,6 +14,7 @@ class SubmissionsController < ApplicationController
   def show
     @online_application = online_application
     @result = storage.submission_result
+    ga_events << ["'send', 'timing', 'Conversion duration', 'complete', '#{storage.time_taken}'"]
     reset_session
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,7 +14,7 @@ class SubmissionsController < ApplicationController
   def show
     @online_application = online_application
     @result = storage.submission_result
-    ga_events << ["'send', 'timing', 'Conversion duration', 'complete', '#{storage.time_taken}'"]
+    ga_events << build_ga_event
     reset_session
   end
 
@@ -22,5 +22,11 @@ class SubmissionsController < ApplicationController
 
   def submit_service
     @submit_service ||= SubmitApplication.new(Settings.submission.url, Settings.submission.token)
+  end
+
+  def build_ga_event
+    time = storage.time_taken < 0 ? 1000 : storage.time_taken
+    type = online_application.benefits ? 'benefit' : 'income'
+    "ga('send', 'timing', 'Application', 'Complete', #{time}, '#{type}')"
   end
 end

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -11,6 +11,12 @@ class Storage
     @session[:started_at].present?
   end
 
+  def time_taken
+    return nil unless started?
+    seconds = (Time.zone.now - started_at).round
+    seconds * 1000 # GA needs milliseconds
+  end
+
   def save_form(form)
     @session['questions'] = {} unless @session['questions']
     @session['questions'][form.id] = form.as_json
@@ -27,5 +33,15 @@ class Storage
 
   def submission_result
     @session[:submission_result]
+  end
+
+  private
+
+  def started_at
+    started_at_as_time || @session[:started_at]
+  end
+
+  def started_at_as_time
+    Time.zone.parse(@session[:started_at]) if @session[:started_at].is_a? String
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,6 +22,15 @@
 
 - content_for :javascripts
   = javascript_include_tag('application.js')
+  javascript:
+    $(document).ready(function () {
+      if ("#{@ga_events}" != "") {
+        var events = JSON.parse("#{@ga_events}".replace(/&quot;/g, '"').replace(/&#39;/g, '\''));
+        $(events).each(function (_index, event) {
+           eval(event);
+        });
+      }
+    });
 
 - content_for :footer_support_links
   li =link_to 'Help', 'http://www.gov.uk/help'

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe SubmissionsController, type: :controller do
 
     before do
       allow(controller).to receive(:reset_session)
+      allow(online_application).to receive(:benefits).and_return(true)
 
       get :show
     end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SubmissionsController, type: :controller do
 
   describe 'GET #show' do
     let(:result) { { result: true, message: 'HWF-010101' } }
-    let(:storage) { double(submission_result: result) }
+    let(:storage) { double(submission_result: result, time_taken: 600) }
 
     before do
       allow(controller).to receive(:reset_session)

--- a/spec/services/storage_spec.rb
+++ b/spec/services/storage_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe Storage do
     end
   end
 
+  describe '#time_taken' do
+    let(:session) { {} }
+
+    subject { storage.time_taken }
+
+    context 'when started_at is not set' do
+      it { is_expected.to be nil }
+    end
+
+    context 'when started_at is stored in the session as a string' do
+      let(:session) { { started_at: current_time.to_s } }
+
+      it { is_expected.to be_a Integer }
+    end
+
+    context 'when started_at is 10 minutes old' do
+      let(:session) { { started_at: current_time - 10.minutes } }
+
+      it { is_expected.to eq 600000 }
+    end
+  end
+
   describe '#save_form' do
     let(:id) { 'ID' }
     let(:json_data) { { some: 'data' } }


### PR DESCRIPTION
This will need testing on demo before it's merged!

This adds a ga_events collection to application controller, then any controller can call 

```ruby
ga_events << "ga('send', 'field', 'foo', 'bar')"
```

This will be processed by a slim embedded javascript block on the layout to submit events to GA.