### PR TITLE
Restrict field character length

### DIFF
--- a/app/models/forms/applicant_address.rb
+++ b/app/models/forms/applicant_address.rb
@@ -3,8 +3,8 @@ module Forms
     attribute :address, String
     attribute :postcode, String
 
-    validates :address, presence: true
-    validates :postcode, presence: true
+    validates :address, presence: true, length: { maximum: 100 }
+    validates :postcode, presence: true, length: { maximum: 10 }
 
     private
 

--- a/app/models/forms/applicant_address.rb
+++ b/app/models/forms/applicant_address.rb
@@ -3,7 +3,7 @@ module Forms
     attribute :address, String
     attribute :postcode, String
 
-    validates :address, presence: true, length: { maximum: 100 }
+    validates :address, presence: true, length: { maximum: 99 }
     validates :postcode, presence: true, length: { maximum: 8 }
 
     private

--- a/app/models/forms/applicant_address.rb
+++ b/app/models/forms/applicant_address.rb
@@ -4,7 +4,7 @@ module Forms
     attribute :postcode, String
 
     validates :address, presence: true, length: { maximum: 100 }
-    validates :postcode, presence: true, length: { maximum: 10 }
+    validates :postcode, presence: true, length: { maximum: 8 }
 
     private
 

--- a/app/models/forms/claim.rb
+++ b/app/models/forms/claim.rb
@@ -4,7 +4,7 @@ module Forms
     attribute :identifier, String
 
     validates :number, inclusion: { in: [true, false] }
-    validates :identifier, presence: true, length: { maximum: 50 }, if: :number?
+    validates :identifier, presence: true, length: { maximum: 25 }, if: :number?
 
     private
 

--- a/app/models/forms/claim.rb
+++ b/app/models/forms/claim.rb
@@ -4,7 +4,7 @@ module Forms
     attribute :identifier, String
 
     validates :number, inclusion: { in: [true, false] }
-    validates :identifier, presence: true, length: { maximum: 25 }, if: :number?
+    validates :identifier, presence: true, length: { maximum: 24 }, if: :number?
 
     private
 

--- a/app/models/forms/claim.rb
+++ b/app/models/forms/claim.rb
@@ -4,10 +4,7 @@ module Forms
     attribute :identifier, String
 
     validates :number, inclusion: { in: [true, false] }
-
-    with_options if: :number do
-      validates :identifier, presence: true
-    end
+    validates :identifier, presence: true, length: { maximum: 50 }, if: :number?
 
     private
 

--- a/app/models/forms/contact.rb
+++ b/app/models/forms/contact.rb
@@ -6,7 +6,7 @@ module Forms
     email_regex = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
     validates :email,
       format: { with: email_regex, allow_nil: true, allow_blank: true },
-      length: { maximum: 100 }
+      length: { maximum: 99 }
     validates :feedback_opt_in, inclusion: { in: [true, false] }
 
     private

--- a/app/models/forms/contact.rb
+++ b/app/models/forms/contact.rb
@@ -4,7 +4,9 @@ module Forms
     attribute :feedback_opt_in, Boolean, default: false
 
     email_regex = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-    validates :email, format: { with: email_regex, allow_nil: true, allow_blank: true }
+    validates :email,
+      format: { with: email_regex, allow_nil: true, allow_blank: true },
+      length: { maximum: 100 }
     validates :feedback_opt_in, inclusion: { in: [true, false] }
 
     private

--- a/app/models/forms/dependent.rb
+++ b/app/models/forms/dependent.rb
@@ -4,10 +4,8 @@ module Forms
     attribute :children_number, Integer
 
     validates :children, inclusion: { in: [true, false] }
-
-    with_options if: :children? do
-      validates :children_number, presence: true, numericality: { allow_blank: true }
-    end
+    validates :children_number,
+      presence: true, numericality: { allow_blank: true, less_than: 100 }, if: :children?
 
     private
 

--- a/app/models/forms/form_name.rb
+++ b/app/models/forms/form_name.rb
@@ -2,6 +2,8 @@ module Forms
   class FormName < Base
     attribute :identifier, String
 
+    validates :identifier, length: { maximum: 50 }
+
     private
 
     def export_params

--- a/app/models/forms/form_name.rb
+++ b/app/models/forms/form_name.rb
@@ -2,7 +2,7 @@ module Forms
   class FormName < Base
     attribute :identifier, String
 
-    validates :identifier, length: { maximum: 50 }
+    validates :identifier, length: { maximum: 49 }
 
     private
 

--- a/app/models/forms/income.rb
+++ b/app/models/forms/income.rb
@@ -26,7 +26,7 @@ module Forms
     attribute :partner_rent_other_property, Float
     attribute :partner_other, Float
 
-    validates :other_description, presence: true, length: { maximum: 20 }, if: :other_income?
+    validates :other_description, presence: true, length: { maximum: 19 }, if: :other_income?
 
     validate :either_other_income
 

--- a/app/models/forms/income.rb
+++ b/app/models/forms/income.rb
@@ -26,7 +26,7 @@ module Forms
     attribute :partner_rent_other_property, Float
     attribute :partner_other, Float
 
-    validates :other_description, presence: true, if: :other_income?
+    validates :other_description, presence: true, length: { maximum: 20 }, if: :other_income?
 
     validate :either_other_income
 

--- a/app/models/forms/personal_detail.rb
+++ b/app/models/forms/personal_detail.rb
@@ -4,8 +4,9 @@ module Forms
     attribute :first_name, String
     attribute :last_name, String
 
-    validates :first_name, presence: true
-    validates :last_name, presence: true
+    validates :title, length: { maximum: 10 }
+    validates :first_name, presence: true, length: { maximum: 50 }
+    validates :last_name, presence: true, length: { maximum: 50 }
 
     private
 

--- a/app/models/forms/personal_detail.rb
+++ b/app/models/forms/personal_detail.rb
@@ -4,9 +4,9 @@ module Forms
     attribute :first_name, String
     attribute :last_name, String
 
-    validates :title, length: { maximum: 10 }
-    validates :first_name, presence: true, length: { maximum: 50 }
-    validates :last_name, presence: true, length: { maximum: 50 }
+    validates :title, length: { maximum: 9 }
+    validates :first_name, presence: true, length: { maximum: 49 }
+    validates :last_name, presence: true, length: { maximum: 49 }
 
     private
 

--- a/app/models/forms/probate.rb
+++ b/app/models/forms/probate.rb
@@ -7,7 +7,7 @@ module Forms
     TIME_LIMIT_FOR_PROBATE = 20
 
     validates :kase, inclusion: { in: [true, false] }
-    validates :deceased_name, presence: true, length: { maximum: 100 }, if: :kase?
+    validates :deceased_name, presence: true, length: { maximum: 99 }, if: :kase?
 
     with_options if: :validate_probate_date_of_death? do
       validates :date_of_death, date: {

--- a/app/models/forms/probate.rb
+++ b/app/models/forms/probate.rb
@@ -7,10 +7,7 @@ module Forms
     TIME_LIMIT_FOR_PROBATE = 20
 
     validates :kase, inclusion: { in: [true, false] }
-
-    with_options if: :kase do
-      validates :deceased_name, presence: true
-    end
+    validates :deceased_name, presence: true, length: { maximum: 100 }, if: :kase?
 
     with_options if: :validate_probate_date_of_death? do
       validates :date_of_death, date: {

--- a/app/views/questions/forms/_personal_detail.html.slim
+++ b/app/views/questions/forms/_personal_detail.html.slim
@@ -1,7 +1,8 @@
 legend.visuallyhidden = t('text', scope: @form.i18n_scope)
 
-.form-group
+.form-group class=('error' if @form.errors[:title].any?)
   = f.label :title, class: 'form-label'
+  span.error-message#title = @form.errors[:title].join(' ') if @form.errors[:title].any?
   = f.text_field :title, class: 'form-control form-control-smaller'
 .form-group class=('error' if @form.errors[:first_name].any?)
   = f.label :first_name, class: 'form-label'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
               inclusion: "Select whether you're paying a fee for a probate case"
             deceased_name:
               blank: "Please enter the deceased's name"
+              too_long: "The name must be less than 100 characters"
             date_of_death:
               blank: "Enter the date of death"
               not_a_date: "Enter the date in this format DD/MM/YYYY"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,10 +103,14 @@ en:
               too_old: Check this date of birth is correct
         forms/personal_detail:
           attributes:
+            title:
+              too_long: "Title must be less than 10 characters"
             first_name:
               blank: 'Enter your first name'
+              too_long: "First name must be less than 50 characters"
             last_name:
               blank: 'Enter your last name'
+              too_long: "Last name must be less than 50 characters"
         forms/applicant_address:
           attributes:
             address:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
           attributes:
             other_description:
               blank: "Enter a description for your income"
+              too_long: "The description must be less than 20 characters"
         forms/fee:
           attributes:
             paid:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
               inclusion: Select whether you have a case, claim or ‘notice to pay’ number
             identifier:
               blank: Enter a case, claim or ‘notice to pay’ number
-              too_long: "The number must be less than 50 characters"
+              too_long: "The number must be less than 25 characters"
         forms/form_name:
           attributes:
             identifier:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
             children_number:
               not_a_number: 'You must enter financially dependent children as a number'
               blank: 'You must enter the number of financially dependent children'
+              less_than: 'You must enter number less than 100'
         forms/income:
           attributes:
             other_description:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,5 +123,6 @@ en:
           attributes:
             email:
               invalid: 'Enter a valid email address'
+              too_long: "Email must be less than 100 characters"
             phone:
               blank: 'Enter your phone number'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,7 @@ en:
         forms/form_name:
           attributes:
             identifier:
-              blank: "Form name can't be blank"
+              too_long: "The form name must be less than 50 characters"
         forms/national_insurance:
           attributes:
             number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,8 +115,10 @@ en:
           attributes:
             address:
               blank: 'Enter your address'
+              too_long: "Address must be less than 100 characters"
             postcode:
               blank: 'Enter your postcode'
+              too_long: "Postcode must be less than 10 characters"
         forms/contact:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
               inclusion: Select whether you have a case, claim or ‘notice to pay’ number
             identifier:
               blank: Enter a case, claim or ‘notice to pay’ number
+              too_long: "The number must be less than 50 characters"
         forms/form_name:
           attributes:
             identifier:

--- a/spec/models/forms/applicant_address_spec.rb
+++ b/spec/models/forms/applicant_address_spec.rb
@@ -1,36 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe Forms::ApplicantAddress, type: :model do
+  let(:address) { 'London' }
+  let(:postcode) { 'LON DON' }
 
-  subject { described_class.new(address: '1 Foo Road', postcode: 'SW1') }
+  subject(:form) { described_class.new(address: address, postcode: postcode) }
 
   describe 'validations' do
-    context 'when all the attributes are provided' do
-      it { expect(subject.valid?).to be true }
-    end
-
     describe 'address' do
       context 'when address not provided' do
-        before { subject.address = '' }
+        let(:address) { '' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
       end
+
+      context 'when provided' do
+        context 'when more than 100 characters long' do
+          let(:address) { 'a' * 101 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when maximum 100 characters long' do
+          let(:address) { 'a' * 100 }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
     end
 
     describe 'postcode' do
       context 'when postcode not provided' do
-        before { subject.postcode = '' }
+        let(:postcode) { '' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
       end
+
+      context 'when provided' do
+        context 'when more than 10 characters long' do
+          let(:postcode) { 'p' * 11 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when maximum 10 characters long' do
+          let(:postcode) { 'p' * 10 }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
     end
   end
 
   describe '#export' do
-    let(:address) { 'London' }
-    let(:postcode) { 'LON DON' }
-
-    subject { described_class.new(address: address, postcode: postcode).export }
+    subject { form.export }
 
     it 'returns hash with address and postcode' do
       is_expected.to eql(address: address, postcode: postcode)

--- a/spec/models/forms/applicant_address_spec.rb
+++ b/spec/models/forms/applicant_address_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe Forms::ApplicantAddress, type: :model do
       end
 
       context 'when provided' do
-        context 'when more than 10 characters long' do
-          let(:postcode) { 'p' * 11 }
+        context 'when more than 8 characters long' do
+          let(:postcode) { 'p' * 9 }
 
           it { is_expected.not_to be_valid }
         end
 
-        context 'when maximum 10 characters long' do
-          let(:postcode) { 'p' * 10 }
+        context 'when maximum 8 characters long' do
+          let(:postcode) { 'p' * 8 }
 
           it { is_expected.to be_valid }
         end

--- a/spec/models/forms/applicant_address_spec.rb
+++ b/spec/models/forms/applicant_address_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Forms::ApplicantAddress, type: :model do
       end
 
       context 'when provided' do
-        context 'when more than 100 characters long' do
-          let(:address) { 'a' * 101 }
+        context 'when more than 99 characters long' do
+          let(:address) { 'a' * 100 }
 
           it { is_expected.not_to be_valid }
         end
 
-        context 'when maximum 100 characters long' do
-          let(:address) { 'a' * 100 }
+        context 'when maximum 99 characters long' do
+          let(:address) { 'a' * 99 }
 
           it { is_expected.to be_valid }
         end

--- a/spec/models/forms/claim_spec.rb
+++ b/spec/models/forms/claim_spec.rb
@@ -1,38 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Forms::Claim, type: :model do
-  subject { described_class.new }
+  subject(:form) { described_class.new(number: number, identifier: identifier) }
 
   describe 'validations' do
+    let(:identifier) { '' }
+
     describe 'number' do
       context 'when true' do
-        before do
-          subject.number = true
-          subject.identifier = 'formy-form'
-        end
+        let(:number) { true }
 
         describe 'identifier' do
           context 'when not provided' do
-            before { subject.identifier = '' }
-
-            it { expect(subject.valid?).to be false }
+            it { is_expected.not_to be_valid }
           end
 
           context 'when provided' do
-            it { expect(subject.valid?).to be true }
+            context 'when more than 50 characters' do
+              let(:identifier) { 'I' * 51 }
+
+              it { is_expected.not_to be_valid }
+            end
+
+            context 'when 50 characters or less' do
+              let(:identifier) { 'I' * 50 }
+
+              it { is_expected.to be_valid }
+            end
           end
         end
 
         context 'when false' do
-          before { subject.number = false }
+          let(:number) { false }
 
-          it { expect(subject.valid?).to be true }
+          it { is_expected.to be_valid }
         end
 
         context 'when not a boolean value' do
-          before { subject.number = 'string' }
+          let(:number) { 'string' }
 
-          it { expect(subject.valid?).to be false }
+          it { is_expected.not_to be_valid }
         end
       end
     end
@@ -41,7 +48,7 @@ RSpec.describe Forms::Claim, type: :model do
   describe '#export' do
     let(:identifier) { 'IDENTIFIER' }
 
-    subject { described_class.new(number: number, identifier: identifier).export }
+    subject { form.export }
 
     context 'when number is true' do
       let(:number) { true }

--- a/spec/models/forms/claim_spec.rb
+++ b/spec/models/forms/claim_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Forms::Claim, type: :model do
           end
 
           context 'when provided' do
-            context 'when more than 50 characters' do
-              let(:identifier) { 'I' * 51 }
+            context 'when more than 25 characters' do
+              let(:identifier) { 'I' * 26 }
 
               it { is_expected.not_to be_valid }
             end
 
-            context 'when 50 characters or less' do
-              let(:identifier) { 'I' * 50 }
+            context 'when 25 characters or less' do
+              let(:identifier) { 'I' * 25 }
 
               it { is_expected.to be_valid }
             end

--- a/spec/models/forms/claim_spec.rb
+++ b/spec/models/forms/claim_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Forms::Claim, type: :model do
           end
 
           context 'when provided' do
-            context 'when more than 25 characters' do
-              let(:identifier) { 'I' * 26 }
+            context 'when more than 24 characters' do
+              let(:identifier) { 'I' * 25 }
 
               it { is_expected.not_to be_valid }
             end
 
-            context 'when 25 characters or less' do
-              let(:identifier) { 'I' * 25 }
+            context 'when less than 25 characters provided' do
+              let(:identifier) { 'I' * 24 }
 
               it { is_expected.to be_valid }
             end

--- a/spec/models/forms/contact_spec.rb
+++ b/spec/models/forms/contact_spec.rb
@@ -1,48 +1,54 @@
 require 'rails_helper'
 
 RSpec.describe Forms::Contact, type: :model do
-  subject do
-    described_class.new(email: 'foo@bar.com',
-                        feedback_opt_in: true)
-  end
+  let(:email) { 'some@email.domain' }
+  let(:feedback_opt_in) { true }
+
+  subject(:form) { described_class.new(email: email, feedback_opt_in: feedback_opt_in) }
 
   describe 'validations' do
     describe 'email' do
-      context 'and valid email is given' do
-        it { expect(subject.valid?).to be true }
+      context 'when valid email is given' do
+        context 'when the email is more than 100 characters' do
+          let(:email) { "#{'A' * 91}@domain.co" }
+
+          it { is_expected.not_to be_valid }
+        end
+        context 'when the email is maximum 100 characters' do
+          let(:email) { "#{'A' * 90}@domain.co" }
+
+          it { is_expected.to be_valid }
+        end
       end
 
-      context 'and invalid email is given' do
-        before { subject.email = 'foobar.com' }
+      context 'when invalid email is given' do
+        let(:email) { 'foobar.com' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
       end
 
-      context 'and email is not given' do
-        before { subject.email = '' }
+      context 'when email is not given' do
+        let(:email) { '' }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
       end
     end
 
     describe 'feedback_opt_in' do
       context 'when true' do
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
       end
 
       context 'when false' do
-        before { subject.feedback_opt_in = false }
+        let(:feedback_opt_in) { false }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
       end
     end
   end
 
   describe '#export' do
-    let(:email) { 'some@email.domain' }
-    let(:feedback_opt_in) { true }
-
-    subject { described_class.new(email: email, feedback_opt_in: feedback_opt_in).export }
+    subject { form.export }
 
     context 'when email is set' do
       it 'the returned hash includes email_contact true and email_address' do

--- a/spec/models/forms/contact_spec.rb
+++ b/spec/models/forms/contact_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Forms::Contact, type: :model do
   describe 'validations' do
     describe 'email' do
       context 'when valid email is given' do
-        context 'when the email is more than 100 characters' do
-          let(:email) { "#{'A' * 91}@domain.co" }
+        context 'when the email is more than 99 characters' do
+          let(:email) { "#{'A' * 90}@domain.co" }
 
           it { is_expected.not_to be_valid }
         end
-        context 'when the email is maximum 100 characters' do
-          let(:email) { "#{'A' * 90}@domain.co" }
+        context 'when the email is maximum 99 characters' do
+          let(:email) { "#{'A' * 89}@domain.co" }
 
           it { is_expected.to be_valid }
         end

--- a/spec/models/forms/dependent_spec.rb
+++ b/spec/models/forms/dependent_spec.rb
@@ -1,41 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe Forms::Dependent, type: :model do
-  subject { described_class.new }
+
+  subject(:form) { described_class.new(children: children, children_number: children_number) }
 
   describe 'validations' do
+    let(:children_number) { nil }
+
     describe 'children' do
       context 'when true' do
-        before do
-          subject.children = true
-          subject.children_number = '4'
+        let(:children) { true }
+
+        context 'when children_number is not supplied' do
+          let(:children_number) { '' }
+
+          it { is_expected.not_to be_valid }
         end
 
-        it { expect(subject.valid?).to be true }
+        context 'when children_number is supplied as a word' do
+          let(:children_number) { 'three' }
 
-        context 'and children_number is not supplied' do
-          before { subject.children_number = '' }
-
-          it { expect(subject.valid?).to be false }
+          it { is_expected.not_to be_valid }
         end
 
-        context 'and children_number is supplied as a word' do
-          before { subject.children_number = 'three' }
+        context 'when children_number is supplied as a number' do
+          context 'when it is over 99' do
+            let(:children_number) { '100' }
 
-          it { expect(subject.valid?).to be false }
+            it { is_expected.not_to be_valid }
+          end
+
+          context 'when it is less or equal than 99' do
+            let(:children_number) { '4' }
+
+            it { is_expected.to be_valid }
+          end
         end
       end
 
       context 'when false' do
-        before { subject.children = false }
+        let(:children) { false }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
       end
 
       context 'when not a boolean value' do
-        before { subject.children = 'string' }
+        let(:children) { 'string' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
       end
     end
   end
@@ -43,7 +55,7 @@ RSpec.describe Forms::Dependent, type: :model do
   describe '#export' do
     let(:children_number) { 3 }
 
-    subject { described_class.new(children: children, children_number: children_number).export }
+    subject { form.export }
 
     context 'when children is true' do
       let(:children) { true }

--- a/spec/models/forms/form_name_spec.rb
+++ b/spec/models/forms/form_name_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Forms::FormName, type: :model do
 
   describe 'validations' do
     describe 'identifier' do
-      context 'when more than 50 characters' do
-        let(:identifier) { 'I' * 51 }
+      context 'when more than 49 characters' do
+        let(:identifier) { 'I' * 50 }
 
         it { is_expected.not_to be_valid }
       end
 
-      context 'when maximum 50 characters long' do
-        let(:identifier) { 'I' * 50 }
+      context 'when maximum 49 characters long' do
+        let(:identifier) { 'I' * 49 }
 
         it { is_expected.to be_valid }
       end

--- a/spec/models/forms/form_name_spec.rb
+++ b/spec/models/forms/form_name_spec.rb
@@ -1,26 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Forms::FormName, type: :model do
-  subject { described_class.new }
+  subject(:form) { described_class.new(identifier: identifier) }
 
   describe 'validations' do
     describe 'identifier' do
-      context 'when provided' do
-        before { subject.identifier = 'N1' }
+      context 'when more than 50 characters' do
+        let(:identifier) { 'I' * 51 }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.not_to be_valid }
       end
 
-      context 'when not provided' do
-        before { subject.identifier = '' }
+      context 'when maximum 50 characters long' do
+        let(:identifier) { 'I' * 50 }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
       end
     end
   end
 
   describe '#export' do
-    subject { described_class.new(identifier: identifier).export }
+    subject { form.export }
 
     context 'when identifier is set and not blank' do
       let(:identifier) { 'IDENTIFIER' }

--- a/spec/models/forms/income_spec.rb
+++ b/spec/models/forms/income_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe Forms::Income, type: :model do
       end
 
       context 'when provided' do
-        let(:other_description) { 'd' * 20 }
+        let(:other_description) { 'd' * 19 }
 
         context 'when other income or other partner income is empty' do
           let(:other) { 100 }
 
-          context 'when the description more than 20 characters' do
-            let(:other_description) { 'd' * 21 }
+          context 'when the description more than 19 characters' do
+            let(:other_description) { 'd' * 20 }
 
             it { is_expected.not_to be_valid }
           end

--- a/spec/models/forms/income_spec.rb
+++ b/spec/models/forms/income_spec.rb
@@ -1,31 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe Forms::Income, type: :model do
-  subject { described_class.new }
+  subject(:form) { described_class.new(params) }
 
   describe 'validations' do
+    let(:other_description) { '' }
+    let(:other) { nil }
+    let(:partner_other) { nil }
+
+    let(:params) { { other_description: other_description, other: other, partner_other: partner_other } }
+
     describe 'other_description' do
-      context 'when no other income recorded' do
+      context 'when empty' do
+        context 'when no other income recorded' do
+          it { is_expected.to be_valid }
+        end
 
-        it { expect(subject.valid?).to be true }
+        context 'when other income recorded' do
+          let(:other) { 100.0 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when partners other income recorded' do
+          let(:partner_other) { 100.0 }
+
+          it { is_expected.not_to be_valid }
+        end
       end
 
-      context 'when other income recorded' do
-        before { subject.other = 100.0 }
+      context 'when provided' do
+        let(:other_description) { 'd' * 20 }
 
-        it { expect(subject.valid?).to be false }
-      end
+        context 'when other income or other partner income is empty' do
+          let(:other) { 100 }
 
-      context 'when partners other income recorded' do
-        before { subject.partner_other = 100.0 }
+          context 'when the description more than 20 characters' do
+            let(:other_description) { 'd' * 21 }
 
-        it { expect(subject.valid?).to be false }
+            it { is_expected.not_to be_valid }
+          end
+
+          context 'when the description is less than 20 characters' do
+            it { is_expected.to be_valid }
+          end
+        end
+
+        context 'when other income or other partner income is empty' do
+          it { is_expected.not_to be_valid }
+        end
       end
     end
   end
 
   describe '#export' do
-    subject { described_class.new(wages: wages, other: other, partner_universal_credit: partner_universal_credit).export }
+    let(:params) { { wages: wages, other: other, partner_universal_credit: partner_universal_credit } }
+
+    subject { form.export }
 
     context 'when some income is set' do
       let(:wages) { 400 }

--- a/spec/models/forms/personal_detail_spec.rb
+++ b/spec/models/forms/personal_detail_spec.rb
@@ -1,38 +1,74 @@
 require 'rails_helper'
 
 RSpec.describe Forms::PersonalDetail, type: :model do
+  let(:title) { 'TITLE' }
+  let(:first_name) { 'FIRST NAME' }
+  let(:last_name) { 'LAST NAME' }
 
-  subject { described_class.new(title: 'Lord', first_name: 'Flash', last_name: 'Gordon') }
+  subject(:form) { described_class.new(title: title, first_name: first_name, last_name: last_name) }
 
   describe 'validations' do
+    describe 'title' do
+      context 'when more than 10 characters long' do
+        let(:title) { 'f' * 11 }
 
-    context 'when all the attributes are provided' do
-      it { expect(subject.valid?).to be true }
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when maximum 10 characters long' do
+        let(:title) { 'f' * 10 }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     describe 'first_name' do
       context 'when not provided' do
-        before { subject.first_name = '' }
+        let(:first_name) { '' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when provided' do
+        context 'when more than 50 characters long' do
+          let(:first_name) { 'f' * 51 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when maximum 50 characters long' do
+          let(:first_name) { 'f' * 50 }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 
     describe 'last_name' do
       context 'when not provided' do
-        before { subject.last_name = '' }
+        let(:last_name) { '' }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when provided' do
+        context 'when more than 50 characters long' do
+          let(:last_name) { 'f' * 51 }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when maximum 50 characters long' do
+          let(:last_name) { 'f' * 50 }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end
 
   describe '#export' do
-    let(:title) { 'TITLE' }
-    let(:first_name) { 'FIRST NAME' }
-    let(:last_name) { 'LAST NAME' }
-
-    subject { described_class.new(title: title, first_name: first_name, last_name: last_name).export }
+    subject { form.export }
 
     it 'returns hash with title, first_name and last_name' do
       is_expected.to eql(title: title, first_name: first_name, last_name: last_name)

--- a/spec/models/forms/personal_detail_spec.rb
+++ b/spec/models/forms/personal_detail_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Forms::PersonalDetail, type: :model do
 
   describe 'validations' do
     describe 'title' do
-      context 'when more than 10 characters long' do
-        let(:title) { 'f' * 11 }
+      context 'when more than 9 characters long' do
+        let(:title) { 'f' * 10 }
 
         it { is_expected.not_to be_valid }
       end
 
-      context 'when maximum 10 characters long' do
-        let(:title) { 'f' * 10 }
+      context 'when maximum 9 characters long' do
+        let(:title) { 'f' * 9 }
 
         it { is_expected.to be_valid }
       end
@@ -30,14 +30,14 @@ RSpec.describe Forms::PersonalDetail, type: :model do
       end
 
       context 'when provided' do
-        context 'when more than 50 characters long' do
-          let(:first_name) { 'f' * 51 }
+        context 'when more than 49 characters long' do
+          let(:first_name) { 'f' * 50 }
 
           it { is_expected.not_to be_valid }
         end
 
-        context 'when maximum 50 characters long' do
-          let(:first_name) { 'f' * 50 }
+        context 'when maximum 49 characters long' do
+          let(:first_name) { 'f' * 49 }
 
           it { is_expected.to be_valid }
         end
@@ -52,14 +52,14 @@ RSpec.describe Forms::PersonalDetail, type: :model do
       end
 
       context 'when provided' do
-        context 'when more than 50 characters long' do
-          let(:last_name) { 'f' * 51 }
+        context 'when more than 49 characters long' do
+          let(:last_name) { 'f' * 50 }
 
           it { is_expected.not_to be_valid }
         end
 
-        context 'when maximum 50 characters long' do
-          let(:last_name) { 'f' * 50 }
+        context 'when maximum 49 characters long' do
+          let(:last_name) { 'f' * 49 }
 
           it { is_expected.to be_valid }
         end

--- a/spec/models/forms/probate_spec.rb
+++ b/spec/models/forms/probate_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe Forms::Probate, type: :model do
 
         describe 'deceased_name' do
           context 'when present' do
-            context 'when more than 100 characters long' do
-              let(:deceased_name) { 'X' * 101 }
+            context 'when more than 99 characters long' do
+              let(:deceased_name) { 'X' * 100 }
 
               it { is_expected.not_to be_valid }
             end
 
             context 'when less than 100 characters long' do
-              let(:deceased_name) { 'X' * 100 }
+              let(:deceased_name) { 'X' * 99 }
 
               it { is_expected.to be_valid }
             end

--- a/spec/models/forms/probate_spec.rb
+++ b/spec/models/forms/probate_spec.rb
@@ -1,82 +1,74 @@
 require 'rails_helper'
 
 RSpec.describe Forms::Probate, type: :model do
-  subject { described_class.new }
+  let(:params) { { kase: kase, deceased_name: deceased_name, date_of_death: date_of_death } }
+  subject(:form) { described_class.new(params) }
 
   describe 'validations' do
+    let(:deceased_name) { nil }
+    let(:date_of_death) { nil }
+
     describe 'kase' do
       context 'when false' do
-        before { subject.kase = false }
+        let(:kase) { false }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be_valid }
+      end
 
-        context 'when "deceased_name" is not set' do
-          before { subject.deceased_name = nil }
+      context 'when true' do
+        let(:kase) { true }
+        let(:deceased_name) { 'foo' }
+        let(:date_of_death) { Time.zone.today - 1.month }
 
-          it { expect(subject.valid?).to be true }
+        describe 'date of death' do
+          describe 'when missing' do
+            let(:date_of_death) { nil }
+
+            it { is_expected.not_to be_valid }
+          end
+
+          describe 'range' do
+            context 'exceeds upper bound' do
+              let(:date_of_death) { Time.zone.tomorrow }
+
+              it { is_expected.not_to be_valid }
+            end
+
+            context 'exceeds lower bound' do
+              let(:date_of_death) { Time.zone.today - 21.years }
+
+              it { is_expected.not_to be_valid }
+            end
+          end
         end
 
-        context 'when "date_of_death" is not set' do
-          before { subject.date_of_death = nil }
+        describe 'deceased_name' do
+          context 'when present' do
+            context 'when more than 100 characters long' do
+              let(:deceased_name) { 'X' * 101 }
 
-          it { expect(subject.valid?).to be true }
+              it { is_expected.not_to be_valid }
+            end
+
+            context 'when less than 100 characters long' do
+              let(:deceased_name) { 'X' * 100 }
+
+              it { is_expected.to be_valid }
+            end
+          end
+
+          context 'when not set' do
+            let(:deceased_name) { nil }
+
+            it { is_expected.not_to be_valid }
+          end
         end
       end
 
       context 'when not a boolean value' do
-        before { subject.kase = 'string' }
+        let(:kase) { 'string' }
 
-        it { expect(subject.valid?).to be false }
-      end
-    end
-
-    context 'when "kase" is true' do
-      before do
-        subject.kase = true
-        # also set default 'good' values
-        subject.date_of_death = Time.zone.today - 1.month
-        subject.deceased_name = 'foo'
-      end
-
-      describe 'date of death' do
-        describe 'is missing' do
-          before { subject.date_of_death = nil }
-
-          it { expect(subject.valid?).to be false }
-
-          context 'it returns an error' do
-            before { subject.valid? }
-
-            it { expect(subject.errors[:date_of_death]).to eq ['Enter the date of death'] }
-          end
-        end
-
-        describe 'range' do
-          context 'exceeds upper bound' do
-            before { subject.date_of_death = Time.zone.tomorrow }
-
-            it { expect(subject.valid?).to be false }
-          end
-
-          context 'exceeds lower bound' do
-            before { subject.date_of_death = Time.zone.today - 21.years }
-
-            it { expect(subject.valid?).to be false }
-          end
-        end
-      end
-
-      describe 'deceased_name' do
-        context 'when "deceased_name" is present' do
-
-          it { expect(subject.valid?).to be true }
-        end
-
-        context 'when "deceased_name" is not set' do
-          before { subject.deceased_name = nil }
-
-          it { expect(subject.valid?).to be false }
-        end
+        it { is_expected.not_to be_valid }
       end
     end
   end
@@ -85,7 +77,7 @@ RSpec.describe Forms::Probate, type: :model do
     let(:deceased_name) { 'Mr. Deceased' }
     let(:date_of_death) { Date.parse('01/01/2016') }
 
-    subject { described_class.new(kase: kase, deceased_name: deceased_name, date_of_death: date_of_death).export }
+    subject { form.export }
 
     context 'when kase is true' do
       let(:kase) { true }


### PR DESCRIPTION
This came out of security / load testing, that our fields should be restricted in what they can accept. 

Essentially the problem is that the encrypted cookie session is quite limited in size, so trying to store very long fields will crash it. We may need to consider using an alternative cookie storage if that becomes too much of an issue.