### PR TITLE
format values on page load

### DIFF
--- a/app/assets/javascripts/modules/income-table.js
+++ b/app/assets/javascripts/modules/income-table.js
@@ -7,6 +7,7 @@ window.moj.Modules.IncomeTable = {
 
     if (self.$tables.length) {
       self.getTotalTables();
+      self.formatExistingValues();
       self.bindEvents();
     }
   },
@@ -24,6 +25,18 @@ window.moj.Modules.IncomeTable = {
   formatValue: function($input) {
     var val = parseFloat($input.val());
     $input.val(val.toFixed(2));
+  },
+
+  formatExistingValues: function() {
+    var self = this;
+
+    self.$tables.find('input.form-control[type="number"]').each(function(n, el) {
+      var $el = $(el);
+
+      if($el.val() !== '') {
+        self.formatValue($el);
+      }
+    });
   },
 
   getTotalTables: function() {


### PR DESCRIPTION
This was actually reported as an iPad bug, but it affected desktop too.

On step 5, income, if an amount was entered into any box then an error triggered, the page would reload and show each amount with a single decimal. (To trigger an error, enter a description for other income but no amount.)

Before
---
![screen shot 2016-04-28 at 11 18 54](https://cloud.githubusercontent.com/assets/988436/14882892/03032ca0-0d33-11e6-8aac-5bd400942413.png)

After
---
![screen shot 2016-04-28 at 11 19 30](https://cloud.githubusercontent.com/assets/988436/14882912/18b49908-0d33-11e6-9649-adc3bbad0313.png)
