### PR TITLE
Healthcheck end-points

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+APPVERSION=something1
+APP_BUILD_DATE=something2
+APP_GIT_COMMIT=something3
+APP_BUILD_TAG=something4

--- a/app/controllers/health_status/health_check_controller.rb
+++ b/app/controllers/health_status/health_check_controller.rb
@@ -1,0 +1,8 @@
+module HealthStatus
+  class HealthCheckController < ApplicationController
+    def show
+      health_check = HealthStatus::HealthCheck.new
+      render json: health_check, status: health_check.status ? 200 : 500
+    end
+  end
+end

--- a/app/controllers/health_status/health_check_controller.rb
+++ b/app/controllers/health_status/health_check_controller.rb
@@ -2,7 +2,7 @@ module HealthStatus
   class HealthCheckController < ApplicationController
     def show
       health_check = HealthStatus::HealthCheck.new
-      render json: health_check, status: health_check.status ? 200 : 500
+      render json: health_check, status: health_check.healthy? ? 200 : 500
     end
   end
 end

--- a/app/controllers/health_status/ping_controller.rb
+++ b/app/controllers/health_status/ping_controller.rb
@@ -1,0 +1,7 @@
+module HealthStatus
+  class PingController < ApplicationController
+    def show
+      render json: HealthStatus::Deployment.new
+    end
+  end
+end

--- a/app/services/health_status/deployment.rb
+++ b/app/services/health_status/deployment.rb
@@ -1,0 +1,12 @@
+module HealthStatus
+  class Deployment
+    def as_json(_options = {})
+      {
+        version_number: Settings.health_status.deployment.version_number,
+        build_date: Settings.health_status.deployment.build_date,
+        commit_id: Settings.health_status.deployment.commit_id,
+        build_tag: Settings.health_status.deployment.build_tag
+      }
+    end
+  end
+end

--- a/app/services/health_status/health_check.rb
+++ b/app/services/health_status/health_check.rb
@@ -1,20 +1,28 @@
 module HealthStatus
   class HealthCheck
     def initialize
+      check_submission_api!
     end
 
     def as_json(_options = {})
       {
         submission_api: {
           description: 'Submission API',
-          ok: true
+          ok: @submission_api_available
         },
-        ok: status
+        ok: @submission_api_available
       }
     end
 
-    def status
-      true
+    def healthy?
+      @submission_api_available
+    end
+
+    private
+
+    def check_submission_api!
+      service = SubmitApplication.new(Settings.submission.url, Settings.submission.token)
+      @submission_api_available = service.available?
     end
   end
 end

--- a/app/services/health_status/health_check.rb
+++ b/app/services/health_status/health_check.rb
@@ -1,0 +1,20 @@
+module HealthStatus
+  class HealthCheck
+    def initialize
+    end
+
+    def as_json(_options = {})
+      {
+        submission_api: {
+          description: 'Submission API',
+          ok: true
+        },
+        ok: status
+      }
+    end
+
+    def status
+      true
+    end
+  end
+end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -4,6 +4,13 @@ class SubmitApplication
     @token = token
   end
 
+  def available?
+    response = RestClient.get "#{@url}/ping.json"
+    response.code == 200
+  rescue
+    false
+  end
+
   def post(online_application)
     response = post_data(online_application)
     JSON.parse(response).deep_symbolize_keys

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
   resource :session, only: :destroy do
     get :start
   end
+
+  get 'ping' => 'health_status/ping#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   end
 
   get 'ping' => 'health_status/ping#show'
+  get 'healthcheck' => 'health_status/health_check#show'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,3 +4,9 @@ submission:
 analytics:
   id: <%= ENV['GA_ID'] || 'UA-37377084-52' %>
   domain: <%= ENV['GA_DOMAIN'] || 'auto' %>
+health_status:
+  deployment:
+    version_number: <%= ENV['APPVERSION'] || 'unknown' %>
+    build_date: <%= ENV['APP_BUILD_DATE'] || 'unknown' %>
+    commit_id:  <%= ENV['APP_GIT_COMMIT'] || 'unknown' %>
+    build_tag:  <%= ENV['APP_BUILD_TAG'] || 'unknown' %>

--- a/spec/controllers/health_status/health_check_controller.rb
+++ b/spec/controllers/health_status/health_check_controller.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe HealthStatus::HealthCheckController, type: :controller do
+  describe '#show' do
+    let(:json) { { some_key: 'some_value' } }
+    let(:health_check) { double(as_json: json, healthy?: healthy?) }
+
+    before do
+      allow(HealthStatus::HealthCheck).to receive(:new).and_return(health_check)
+
+      get :show
+    end
+
+    context 'when the health check reports as healthy' do
+      let(:healthy?) { true }
+
+      it 'responds with 200 status' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'renders the health check json' do
+        expect(response.body).to eql(json.to_json)
+      end
+    end
+
+    context 'when the health check reports as unhealthy' do
+      let(:healthy?) { false }
+
+      it 'responds with 500 status' do
+        expect(response).to have_http_status(500)
+      end
+
+      it 'renders the health check json' do
+        expect(response.body).to eql(json.to_json)
+      end
+    end
+  end
+end

--- a/spec/controllers/health_status/ping_controller_spec.rb
+++ b/spec/controllers/health_status/ping_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe HealthStatus::PingController, type: :controller do
+
+  describe 'GET #show' do
+    before(:each) { get :show }
+
+    it 'returns success code' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns JSON' do
+      expect(response.content_type).to eq('application/json')
+    end
+
+    describe 'renders correct json' do
+      let(:json) { JSON.parse(response.body) }
+      let(:keys) do
+        ["version_number",
+         "build_date",
+         "commit_id",
+         "build_tag"]
+      end
+
+      it 'has ping.json schema defined keys' do
+        expect(json.keys).to eq keys
+      end
+
+      it 'key count' do
+        expect(json.count).to eq 4
+      end
+    end
+  end
+end

--- a/spec/controllers/health_status/ping_controller_spec.rb
+++ b/spec/controllers/health_status/ping_controller_spec.rb
@@ -3,32 +3,25 @@ require 'rails_helper'
 RSpec.describe HealthStatus::PingController, type: :controller do
 
   describe 'GET #show' do
-    before(:each) { get :show }
+    let(:json) { { some_key: 'some value' } }
+    let(:deployment) { double(as_json: json) }
+
+    before(:each) do
+      allow(HealthStatus::Deployment).to receive(:new).and_return(deployment)
+
+      get :show
+    end
 
     it 'returns success code' do
       expect(response).to have_http_status(:success)
     end
 
-    it 'returns JSON' do
+    it 'returns JSON content type' do
       expect(response.content_type).to eq('application/json')
     end
 
-    describe 'renders correct json' do
-      let(:json) { JSON.parse(response.body) }
-      let(:keys) do
-        ["version_number",
-         "build_date",
-         "commit_id",
-         "build_tag"]
-      end
-
-      it 'has ping.json schema defined keys' do
-        expect(json.keys).to eq keys
-      end
-
-      it 'key count' do
-        expect(json.count).to eq 4
-      end
+    it 'returns the deployment json in the body' do
+      expect(response.body).to eql(json.to_json)
     end
   end
 end

--- a/spec/services/health_status/deployment_spec.rb
+++ b/spec/services/health_status/deployment_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe HealthStatus::Deployment, type: :service do
+  subject(:service) { described_class.new }
+
+  describe '#as_json' do
+    let(:version_number) { 'VN' }
+    let(:build_date) { 'BD' }
+    let(:commit_id) { 'CI' }
+    let(:build_tag) { 'BT' }
+
+    let(:settings) { double(version_number: version_number, build_date: build_date, commit_id: commit_id, build_tag: build_tag) }
+
+    before do
+      allow(Settings.health_status).to receive(:deployment).and_return(settings)
+    end
+
+    it 'returns hash with deployment information available from the Settings' do
+      expect(service.as_json).to eql(
+        version_number: version_number,
+        build_date: build_date,
+        commit_id: commit_id,
+        build_tag: build_tag
+      )
+    end
+  end
+end

--- a/spec/services/health_status/health_check_spec.rb
+++ b/spec/services/health_status/health_check_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe HealthStatus::HealthCheck, type: :service do
+  subject(:service) { described_class.new }
+
+  let(:submit_application) { double(available?: submit_application_available?) }
+
+  before do
+    allow(SubmitApplication).to receive(:new).and_return(submit_application)
+  end
+
+  describe '#as_json' do
+    subject { service.as_json }
+
+    context 'when the submission api is available' do
+      let(:submit_application_available?) { true }
+
+      it 'returns hash with all services ok' do
+        is_expected.to eql(
+          submission_api: {
+            description: 'Submission API',
+            ok: true
+          },
+          ok: true
+        )
+      end
+    end
+
+    context 'when the submission api is not available' do
+      let(:submit_application_available?) { false }
+
+      it 'returns hash with services unavailable' do
+        is_expected.to eql(
+          submission_api: {
+            description: 'Submission API',
+            ok: false
+          },
+          ok: false
+        )
+      end
+
+    end
+  end
+
+  describe '#healthy?' do
+    subject { service.healthy? }
+
+    context 'when the submission api is available' do
+      let(:submit_application_available?) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the submission api is not available' do
+      let(:submit_application_available?) { false }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -7,6 +7,38 @@ RSpec.describe SubmitApplication do
 
   subject(:submit_application) { described_class.new(url, token) }
 
+  describe '#available?' do
+    let(:request_path) { "#{url}/ping.json" }
+
+    subject { submit_application.available? }
+
+    context 'when the connection is working' do
+      before do
+        stub_request(:get, request_path).to_return(status: status)
+      end
+
+      context 'when the response status is 200' do
+        let(:status) { 200 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the response status is anything else than 200' do
+        let(:status) { 500 }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when the connection can not be established' do
+      before do
+        stub_request(:get, request_path).to_raise
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#post' do
     subject(:post) { submit_application.post(online_application) }
 


### PR DESCRIPTION
Adding the `/ping.json` and `/healthcheck.json` end-points. 

* `ping.json` contains deployment information (if available)
* `healthcheck.json` contains status of the service and its downstream dependencies

As opposed to our `fr-staffapp` I namespaced this functionality and added more tests. My original idea was to take this whole thing to an engine gem, which would allow mounting it to other MoJ projects as well. But that can be done separately when we have some time.