### PR TITLE
Move GA script to the footer

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -22,6 +22,7 @@
 
 - content_for :javascripts
   = javascript_include_tag('application.js')
+  = render 'shared/analytics'
   javascript:
     $(document).ready(function () {
       if ("#{@ga_events}" != "") {
@@ -39,5 +40,5 @@
   li =link_to 'Terms and conditions', terms_and_conditions_path
   li =link_to 'Cymraeg', 'http://www.gov.uk/cymraeg', lang: 'cy'
 
-= render 'shared/analytics'
+
 = render template: "layouts/moj_template"


### PR DESCRIPTION
The GA script is now on top of the layout before the <html> tag, which is not W3C compliant. Also if there's a problem with loading the script, it could slow down the whole page.