### PR TITLE
prevent NaN console message on income table when tabbing

### DIFF
--- a/app/assets/javascripts/modules/income-table.js
+++ b/app/assets/javascripts/modules/income-table.js
@@ -18,7 +18,10 @@ window.moj.Modules.IncomeTable = {
     self.$tables.find('input.form-control[type="number"]').on('keyup', function() {
       self.getTotalTables();
     }).on('blur', function(e) {
-      self.formatValue($(e.target));
+      var $el = $(e.target);
+      if($el.val() !== '') {
+        self.formatValue($el);
+      }
     });
   },
 


### PR DESCRIPTION
fixing a minor JS niggle - only format currency value if there is one