### PR TITLE
Session time out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  rescue_from Storage::Expired, with: :expired_redirect
+
   private
 
   def online_application
@@ -25,6 +27,11 @@ class ApplicationController < ActionController::Base
 
   def redirect_if_storage_unstarted
     redirect_to(root_path) unless storage.started?
+  end
+
+  def expired_redirect
+    flash[:error] = t('session.expired_message')
+    redirect_to(root_path)
   end
 
   def ga_events

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -54,19 +54,15 @@ class Storage
   end
 
   def used_at
-    used_at_as_time || @session[:used_at]
-  end
-
-  def used_at_as_time
-    Time.zone.parse(@session[:used_at]) if @session[:used_at].is_a? String
+    field_as_time(:used_at)
   end
 
   def started_at
-    started_at_as_time || @session[:started_at]
+    field_as_time(:started_at)
   end
 
-  def started_at_as_time
-    Time.zone.parse(@session[:started_at]) if @session[:started_at].is_a? String
+  def field_as_time(field)
+    @session[field].is_a?(String) ? Time.zone.parse(@session[field]) : @session[field]
   end
 
   def expires_in_seconds

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -1,6 +1,10 @@
 class Storage
+  class Expired < StandardError; end
+
   def initialize(session)
     @session = session
+    raise Expired if expired?
+    @session[:used_at] = Time.zone.now
   end
 
   def start
@@ -36,6 +40,18 @@ class Storage
   end
 
   private
+
+  def expired?
+    @session[:used_at] && ((Time.zone.now - used_at).round >= 600)
+  end
+
+  def used_at
+    used_at_as_time || @session[:used_at]
+  end
+
+  def used_at_as_time
+    Time.zone.parse(@session[:used_at]) if @session[:used_at].is_a? String
+  end
 
   def started_at
     started_at_as_time || @session[:started_at]

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -3,8 +3,7 @@ class Storage
 
   def initialize(session)
     @session = session
-    raise Expired if expired?
-    @session[:used_at] = Time.zone.now
+    check_expiration!
   end
 
   def start
@@ -40,6 +39,15 @@ class Storage
   end
 
   private
+
+  def check_expiration!
+    if started? && expired?
+      @session.destroy
+      raise Expired
+    else
+      @session[:used_at] = Time.zone.now
+    end
+  end
 
   def expired?
     @session[:used_at] && ((Time.zone.now - used_at).round >= 600)

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -50,7 +50,7 @@ class Storage
   end
 
   def expired?
-    @session[:used_at] && ((Time.zone.now - used_at).round >= 600)
+    @session[:used_at] && ((Time.zone.now - used_at).round >= expires_in_seconds)
   end
 
   def used_at
@@ -67,5 +67,9 @@ class Storage
 
   def started_at_as_time
     Time.zone.parse(@session[:started_at]) if @session[:started_at].is_a? String
+  end
+
+  def expires_in_seconds
+    Settings.session.expires_in_minutes * 60
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -42,5 +42,10 @@ p Applying takes around 10 minutes. This service is for England and Wales only.
 
 = link_to(t('start_application'), start_session_path, role: :button, class: 'button button-start')
 
+p.util_mt-large
+  strong.block.bold-small =t('session.note.heading')
+  strong.block
+    =t('session.note.text')
+
 h2.heading-large Other ways to apply
 p You can also apply by post using the #{link_to '‘Apply for help with fees (EX160)’ (PDF 82KB)', 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex160-eng-20160212.pdf', class: 'external', rel: 'external'} form.

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -16,4 +16,9 @@ h1.heading-large
     .form-group
       = f.submit t('submit_button'), class: 'button'
 
+p
+  strong.block.bold-small =t('session.note.heading')
+  strong.block
+    =t('session.note.text')
+
 =render('shared/restart_application_link')

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -87,4 +87,9 @@ p =t('statement', scope: 'summary.truth')
 = form_tag(submission_path, method: :post, class: 'util_mb-medium util_mt-medium') do
   = submit_tag(t('button', scope: 'summary.truth'), class: 'button', role: 'button')
 
+p
+  strong.block.bold-small =t('session.note.heading')
+  strong.block
+    =t('session.note.text')
+
 =render('shared/restart_application_link')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
   error_block:
     heading: 'You need to fix the errors on this page before continuing.'
     visuallyhidden: 'Errors are listed as links below, click to select the field that needs correcting.'
+  session:
+    expired_message: "You didn't enter any information for more than 10 minutes so you need to start your application again."
   errors:
     combined_other_payments_invalid: 'Enter the amount of your income'
   activemodel:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,9 @@ en:
     visuallyhidden: 'Errors are listed as links below, click to select the field that needs correcting.'
   session:
     expired_message: "You didn't enter any information for more than 10 minutes so you need to start your application again."
+    note:
+      heading: Please note
+      text: "If you don’t enter any information for more than 10 minutes, then your session will time out and you’ll need to start again."
   errors:
     combined_other_payments_invalid: 'Enter the amount of your income'
   activemodel:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,5 @@ zendesk:
   url: <%= ENV['ZENDESK_URL'] %>
   username: <%= ENV['ZENDESK_USERNAME'] %>
   token: <%= ENV['ZENDESK_TOKEN'] %>
+session:
+  expires_in_minutes: 10

--- a/spec/features/session_expires_when_inactive_spec.rb
+++ b/spec/features/session_expires_when_inactive_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'Session expires when inactive' do
+
+  let(:time_started) { Time.zone.now }
+  let(:time_expired) { time_started + 61.minutes }
+
+  scenario 'When user is inactive for given time while answering questions, the session expires' do
+    Timecop.freeze(time_started) do
+      given_user_fills_in_few_questions
+    end
+    Timecop.freeze(time_expired) do
+      when_they_try_to_proceed_after_long_time
+      then_they_are_redirected_to_homepage_with_expiry_message
+    end
+  end
+
+  scenario 'The session does not expire when on the start page' do
+    Timecop.freeze(time_started) do
+      given_user_is_reading_the_home_page
+    end
+    Timecop.freeze(time_expired) do
+      when_they_start_new_application
+      then_they_are_on_the_first_question
+    end
+  end
+end

--- a/spec/features/user_submits_their_application_spec.rb
+++ b/spec/features/user_submits_their_application_spec.rb
@@ -14,10 +14,10 @@ RSpec.feature 'User submits their application' do
   scenario 'User submits their refund application and it is successfully processed' do
     Timecop.freeze(current_time) do
       given_user_provides_all_data_for_refund
+      and_the_submission_service_is_available(reference)
+      when_they_submit_the_application
+      then_they_are_presented_with_the_refund_confirmation_page_with_reference_number
     end
-    and_the_submission_service_is_available(reference)
-    when_they_submit_the_application
-    then_they_are_presented_with_the_refund_confirmation_page_with_reference_number
   end
 
   scenario 'User submits their application, but it is not processed' do

--- a/spec/services/storage_spec.rb
+++ b/spec/services/storage_spec.rb
@@ -5,6 +5,44 @@ RSpec.describe Storage do
 
   subject(:storage) { described_class.new(session) }
 
+  describe '#initialize' do
+    let(:session) { { used_at: used_at.to_s } }
+
+    subject do
+      Timecop.freeze(current_time) do
+        storage
+      end
+    end
+
+    context 'when it was used more than 10 minutes ago' do
+      let(:used_at) { current_time - 11.minutes }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Storage::Expired)
+      end
+    end
+
+    context 'when it was used less than 10 minutes ago' do
+      let(:used_at) { current_time - 5.minutes }
+
+      before { subject }
+
+      it 'stores the current time to the session, as time of last used' do
+        expect(session[:used_at]).to eql(current_time)
+      end
+    end
+
+    context 'when the storage was just initialised for the first time' do
+      let(:session) { {} }
+
+      before { subject }
+
+      it 'stores the current time to the session, as time of last used' do
+        expect(session[:used_at]).to eql(current_time)
+      end
+    end
+  end
+
   describe '#start' do
     let(:session) { {} }
 

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -41,17 +41,29 @@ module FeatureSteps
     given_user_answers_questions_up_to(:dependent)
   end
 
+  def given_user_is_reading_the_home_page
+    visit '/'
+  end
+
   def when_they_submit_the_application
     click_link_or_button 'Complete application'
   end
 
+  def when_they_start_new_application
+    click_link_or_button 'Apply now'
+  end
+
   def when_they_go_back_to_homepage_and_start_again
     visit '/'
-    click_link_or_button 'Apply now'
+    when_they_start_new_application
   end
 
   def when_they_restart_the_application
     click_link_or_button 'Start a new application'
+  end
+
+  def when_they_try_to_proceed_after_long_time
+    fill_dependent
   end
 
   def then_their_data_is_not_persisted
@@ -60,6 +72,15 @@ module FeatureSteps
     expect(form_name).to be_empty
   end
   alias then_their_data_is_deleted then_their_data_is_not_persisted
+
+  def then_they_are_redirected_to_homepage_with_expiry_message
+    expect(page).to have_text 'Apply for help with fees'
+    expect(page).to have_text "You didn't enter any information for more than 10 minutes so you need to start your application again."
+  end
+
+  def then_they_are_on_the_first_question
+    expect(page).to have_text 'What court or tribunal fee do you need help with?'
+  end
 
   def fill_contact
     fill_in 'contact_email', with: 'foo@bar.com'


### PR DESCRIPTION
The user has 10 minutes of inactivity before the session expires. There's no warning of that happening at the moment, only an error after. There will be a subsequent story on the backlog to improve this. 

It's mostly a prerequisite for us to be able to improve the confirmation page.


Also I think it's time to start thinking about the `Storage` class and maybe how can we split it into smaller and simpler services / classes. It's getting quite chunky and maybe it has too much responsibility. I'll do so in the following work.