### PR TITLE
Update future refund error handling

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
               blank: "Enter the date in this format DD/MM/YYYY"
               not_a_date: "That date is not recognised"
               after_or_equal_to: "The application must have been made in the last 3 months"
-              before: "This date can't be in the future"
+              before_or_equal_to: "This date can't be in the future"
         forms/probate:
           attributes:
             kase:

--- a/spec/features/pages/fee_question_spec.rb
+++ b/spec/features/pages/fee_question_spec.rb
@@ -69,6 +69,21 @@ RSpec.feature 'As a user' do
             expect(page).to have_xpath("//input[@id='fee_date_paid' and @value='#{4.months.ago.strftime('%d/%m/%Y')}']")
           end
         end
+
+        describe 'when the date is in the future' do
+          before do
+            fill_in 'fee_date_paid', with: Time.zone.now + 1.month
+            click_button 'Continue'
+          end
+
+          scenario 'I expect the fields to have specific errors' do
+            expect(page).to have_xpath('//span[@class="error-message"]', text: "This date can't be in the future")
+          end
+
+          scenario 'I expect the incorrect data to be shown' do
+            expect(page).to have_xpath("//input[@id='fee_date_paid' and @value='#{(Time.zone.now + 1.month).strftime('%d/%m/%Y')}']")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When a refund date is entered for the future the error message wasn't displaying correctly.
[screenshot](https://www.pivotaltracker.com/file_attachments/62230159/download?inline=true)

Added a test for the correct handling and then updated the locale file to display the proper message

[Pivotal ticket](https://www.pivotaltracker.com/story/show/120938009)