### PR TITLE
Always use current date for refund calculation

### DIFF
--- a/app/models/forms/fee.rb
+++ b/app/models/forms/fee.rb
@@ -7,13 +7,21 @@ module Forms
 
     with_options if: :validate_fee_date_paid? do
       validates :date_paid, date: {
-        after_or_equal_to: Time.zone.today - 3.months,
-        before_or_equal_to: Time.zone.today,
+        after_or_equal_to: :min_date,
+        before_or_equal_to: :max_date,
         allow_blank: false
       }
     end
 
     private
+
+    def min_date
+      Time.zone.today - 3.months
+    end
+
+    def max_date
+      Time.zone.today
+    end
 
     def validate_fee_date_paid?
       validate_date? 'date_paid' if paid?


### PR DESCRIPTION
This was a bug when the today's date for refund was cached on app server
start.