### PR TITLE
Fix claim number form labels

### DIFF
--- a/app/views/questions/forms/claim/_default.html.slim
+++ b/app/views/questions/forms/claim/_default.html.slim
@@ -3,16 +3,16 @@ legend.visuallyhidden = t('hidden_legend', scope: @form.i18n_scope)
 .form-group class=('error' if @form.errors[:number].any?)
   = f.hidden_field :number, value: nil
   span.error-message#kase = @form.errors[:number].join(' ') if @form.errors[:number].any?
-  label.block-label for='claim_number_false'
+  label.block-label for='claim_default_number_false'
     = f.radio_button :number, 'false'
     = t('number_false', scope: @form.i18n_scope)
-  label.block-label for='claim_number_true' data-target='claim-identifier-panel'
+  label.block-label for='claim_default_number_true' data-target='claim-identifier-panel'
     = f.radio_button :number, 'true'
     = t('number_true', scope: @form.i18n_scope)
   #claim-identifier-panel.panel-indent.util_mb-medium.js-hidden
     .form-group class=('error' if @form.errors[:identifier].any?)
       span.error-message#identifier = @form.errors[:identifier].join(' ') if @form.errors[:identifier].any?
-      label.form-label(for='claim_identifier')
+      label.form-label(for='claim_default_identifier')
         = t('identifier', scope: @form.i18n_scope)
       = f.text_field :identifier, class: 'form-control'
 


### PR DESCRIPTION
They got wrong when the question become dynamic based on standard / ET
flow. Now they're fixed for the standard flow.