### PR TITLE
fix date format in hints for screenreaders

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -20,3 +20,7 @@ strong {
 #global-header .header-proposition a#proposition-name:hover {
   text-decoration: none;
 }
+
+.dateFormatAccessible {
+  letter-spacing: -1.6px;
+}

--- a/app/views/questions/forms/_dob.html.slim
+++ b/app/views/questions/forms/_dob.html.slim
@@ -2,6 +2,6 @@ legend.visuallyhidden =t('text', scope: @form.i18n_scope)
 .form-group  class=('error' if @form.errors.any?)
   label.form-label for='dob_date_of_birth'
     span.visuallyhidden =t('date_of_birth', scope: @form.i18n_scope)
-    span.hint = t('hint', scope: @form.i18n_scope)
+    span.hint = t('hint_html', scope: @form.i18n_scope)
     span.error-message#date_of_birth = @form.errors[:date_of_birth].join(' ') if @form.errors[:date_of_birth].any?
   = f.text_field :date_of_birth, class: 'form-control'

--- a/app/views/questions/forms/_fee.html.slim
+++ b/app/views/questions/forms/_fee.html.slim
@@ -14,5 +14,5 @@ legend.visuallyhidden = t('text', scope: @form.i18n_scope)
       span.error-message#date_paid = @form.errors[:date_paid].join(' ') if @form.errors[:date_paid].any?
       = f.label :date_paid, class: 'form-label'
       span.visuallyhidden .
-      .hint = t('hint', scope: @form.i18n_scope)
+      .hint = t('hint_html', scope: @form.i18n_scope)
       = f.text_field :date_paid, class: 'form-control'

--- a/app/views/questions/forms/_probate.html.slim
+++ b/app/views/questions/forms/_probate.html.slim
@@ -18,5 +18,5 @@ legend.visuallyhidden= t('text', scope: @form.i18n_scope)
       span.error-message#date_of_death = @form.errors[:date_of_death].join(' ') if @form.errors[:date_of_death].any?
       = f.label :date_of_death, class: 'form-label'
       span.visuallyhidden .
-      .hint = t('hint', scope: @form.i18n_scope)
+      .hint = t('hint_html', scope: @form.i18n_scope)
       = f.text_field :date_of_death, class: 'form-control'

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -147,7 +147,7 @@ en:
       breadcrumb: 'Step 7 of 17'
       text: 'Have you already paid the fee?'
       details: "You can apply for a refund for a fee paid in the last 3 months. If you’re applying for a refund, you should answer all questions about your circumstances at the time you paid the fee."
-      hint: Use this format DD/MM/YYYY
+      hint_html: 'Use this format <span class="dateFormatAccessible">D D / M M / Y Y Y Y</span>'
     probate:
       title: 'Probate'
       probate_case_false: 'No'
@@ -155,7 +155,7 @@ en:
       breadcrumb: 'Step 8 of 17'
       text: 'Are you paying a fee for a probate case?'
       details: 'These cases are usually about the property and belongings of someone who has died.'
-      hint: Use this format DD/MM/YYYY
+      hint_html: 'Use this format <span class="dateFormatAccessible">D D / M M / Y Y Y Y</span>'
     claim/default:
       title: 'Claim or case number'
       breadcrumb: 'Step 9 of 17'
@@ -196,8 +196,7 @@ en:
       title: 'Date of birth'
       breadcrumb: 'Step 11 of 17'
       text: What is your date of birth?
-      subtext: 'Enter the date in this format: DD/MM/YYYY'
-      hint: Use this format DD/MM/YYYY
+      hint_html: 'Use this format <span class="dateFormatAccessible">D D / M M / Y Y Y Y</span>'
     personal_detail:
       title: 'Your name'
       breadcrumb: 'Step 12 of 17'


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/120178605)

When I came to test this in JAWS 17 I found that it was in fact reading out the second slash, but not the fourth Y, so I was hearing "D D slash M M slash Y Y Y edit" (edit meaning that this was an editable text box, and was expected)

This PR inserts spaces between each character, which makes JAWS read the format hint correctly, then uses CSS `letter-spacing` to visually drag the characters back together.