### PR TITLE
New window warning

### DIFF
--- a/app/assets/javascripts/modules/external-links.js
+++ b/app/assets/javascripts/modules/external-links.js
@@ -2,6 +2,25 @@
 
 window.moj.Modules.ExternalLinks = {
   init: function() {
-    $('a[rel="external"]').attr('target', '_blank');
+    var self = this;
+
+    self.setupExternalLinks($('a[rel~="external"]'));
+  },
+
+  setupExternalLinks: function(obj) {
+    obj.each(function(n, el) {
+      var $el = $(el),
+          winStr = ' (Opens in a new window/tab)',
+          currRel = $el.attr('rel'),
+          newRel = currRel + ' noopener',
+          currTitle = $el.attr('title') ? $el.attr('title') : $el.text(),
+          newTitle = currTitle + winStr;
+
+      $el.attr({
+        'rel': newRel,
+        'target': '_blank',
+        'title': newTitle
+      }).html($el.html() + '<span class="visuallyhidden">' + winStr + '</span>');
+    });
   }
 };

--- a/app/assets/stylesheets/local/links.scss
+++ b/app/assets/stylesheets/local/links.scss
@@ -1,3 +1,32 @@
 a.skiplink {
   background: $white;
 }
+
+
+
+a[rel~="external"]:after {
+  background-image: asset-url('external-links/external-link.png');
+  background-repeat: no-repeat;
+}
+  @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20 / 10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+    a[rel~="external"]:after {
+      background-image: asset-url('external-links/external-link-24x24.png');
+      background-size: 12px 400px;
+      }
+    }
+a[rel~="external"]:after {
+  content: "\A0\A0\A0\A0";
+  background-position: right 6px;
+}
+a[rel~="external"]:hover:after {
+  background-position: right -382px;
+}
+@media (max-width: 640px) {
+  a[rel~="external"]:after {
+    content: "\A0\A0\A0\A0\A0";
+    background-position: right 3px;
+  }
+  a[rel~="external"]:hover:after {
+    background-position: right -385px;
+  }
+}


### PR DESCRIPTION
At the moment the only clue that a link will open in a new window is a visual icon, which is no good to blind users.

This expands the JS by adding a text warning about this to both the title attribute of the link, and the link text itself (using the `visuallyhidden` CSS class).

Additionally, since we are applying `target="_blank"` to these links, it's advisable to also add `rel="noopener"`, because [security](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/). Unfortunately, the gov.uk elements CSS for external links didn't support multiple values on the `rel` attribute, so some CSS patching was needed.