### PR TITLE
Make errors H2, move below H1

### DIFF
--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -2,13 +2,13 @@
   = t('title', scope: @form.i18n_scope)
   = ' - '
 
-= render('shared/error_block', form: @form) if @form.errors.any?
-
 h1.heading-large
   span.heading-secondary= t('breadcrumb', scope: @form.i18n_scope)
   span.visuallyhidden
     | :&nbsp;
   = t('text', scope: @form.i18n_scope)
+
+= render('shared/error_block', form: @form) if @form.errors.any?
 
 =render("questions/headers/#{@form.id}")
 

--- a/app/views/shared/_error_block.html.slim
+++ b/app/views/shared/_error_block.html.slim
@@ -1,5 +1,5 @@
 .error-summary role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1"
-  h1.heading-medium.error-summary-heading#error-summary-heading-example-1 You need to fix the errors on this page before continuing.
+  h2.heading-medium.error-summary-heading#error-summary-heading-example-1 You need to fix the errors on this page before continuing.
   span.visuallyhidden Errors are listed as links below, click to select the field that needs correcting.
   ul.error-summary-list
     - form.errors.each do |field, message|


### PR DESCRIPTION
Our error summary title is a `<h1>` tag, as is our main page title or question. Making the error summary title into a `<h2>` tag, means it should go after the `<h1>`.

Thoughts?

Before
---
![before](https://cloud.githubusercontent.com/assets/988436/16008943/64aeb2b8-3172-11e6-9b88-2ffe354cc455.png)

After
---
![after](https://cloud.githubusercontent.com/assets/988436/16008949/6a101580-3172-11e6-8cb3-16297dcb45f4.png)
