### PR TITLE
Fix single word/short links

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -27,7 +27,7 @@ ul.list.list-bullet
   li your court fee is more than £1,000
   li you earn more than £1,085 a month (before tax and National Insurance is taken off) and you have financially dependent children
 
-p See the #{link_to 'guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf', class: "external", rel: "external"} for detailed information about who is eligible to apply for help with fees.
+p See #{link_to 'the guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf', class: "external", rel: "external"} for detailed information about who is eligible to apply for help with fees.
 
 h2.heading-large What you'll need:
 ul.list.list-bullet

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -59,8 +59,7 @@ table
           | Change
           span.visuallyhidden
             | &nbsp;
-            =t('income', scope: 'summary.labels')
-
+            =t('income', scope: 'summary.labels').downcase
     tr
       td =t('fee', scope: 'summary.labels')
       td =@summary.refund_text

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -13,77 +13,146 @@ table
     tr
       td =t('form_name', scope: 'summary.labels')
       td=@summary.form_name
-      td.right= link_to "Change", question_path(:form_name)
+      td.right= link_to question_path(:form_name) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('form_name', scope: 'summary.labels').downcase
     tr
       td =t('married', scope: 'summary.labels')
       td= t("marital_status_#{@summary.married}", scope: 'summary')
-      td.right= link_to "Change", question_path(:marital_status)
+      td.right= link_to question_path(:marital_status) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('married', scope: 'summary.labels').downcase
     tr
       td =t('savings', scope: 'summary.labels')
       td= t("less_than_limit_#{!@summary.threshold_exceeded}", scope: 'summary')
-      td.right= link_to "Change", question_path(:savings_and_investment)
+      td.right= link_to question_path(:savings_and_investment) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('savings', scope: 'summary.labels').downcase
     tr
       td =t('benefits', scope: 'summary.labels')
       td= t("applicant_on_benefits_#{@summary.benefits}", scope: 'summary')
-      td.right= link_to "Change", question_path(:benefit)
+      td.right= link_to question_path(:benefit) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('benefits', scope: 'summary.labels').downcase
     - if @summary.children_text
       tr
         td =t('children', scope: 'summary.labels')
         td =@summary.children_text
-        td.right= link_to "Change", question_path(:dependent)
+        td.right= link_to question_path(:dependent) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('children', scope: 'summary.labels').downcase
     - if @summary.income
       tr
         td =t('income', scope: 'summary.labels')
         td =number_to_currency(@summary.income, precision: 2, unit: '£')
-        td.right= link_to "Change", question_path(:income)
+        td.right= link_to question_path(:income) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('income', scope: 'summary.labels')
+
     tr
       td =t('fee', scope: 'summary.labels')
       td =@summary.refund_text
-      td.right= link_to "Change", question_path(:fee)
+      td.right= link_to question_path(:fee) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('fee', scope: 'summary.labels').downcase
     -if @summary.probate
       tr
         td = t('deceased_name', scope: 'summary.labels')
         td =@summary.deceased_name
-        td.right= link_to "Change", question_path(:probate)
+        td.right= link_to question_path(:probate) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('deceased_name', scope: 'summary.labels').downcase
       tr
         td = t('date_of_death', scope: 'summary.labels')
         td =@summary.date_of_death
-        td.right= link_to "Change", question_path(:probate)
+        td.right= link_to question_path(:probate) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('date_of_death', scope: 'summary.labels').downcase
     -else
       tr
         td =t('probate', scope: 'summary.labels')
         td=t("probate_case_#{@summary.probate}", scope: 'summary')
-        td.right= link_to "Change", question_path(:probate)
+        td.right= link_to question_path(:probate) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('probate', scope: 'summary.labels').downcase
     tr
       td =t('claim', scope: 'summary.labels')
       td =t("claim_number_#{@summary.case_number?}", scope: 'summary')
-      td.right= link_to "Change", question_path(:claim)
+      td.right= link_to question_path(:claim) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('claim', scope: 'summary.labels').downcase
     tr
       td =t('ni_number', scope: 'summary.labels')
       td =@summary.ni_number
-      td.right= link_to "Change", question_path(:national_insurance)
+      td.right= link_to question_path(:national_insurance) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('ni_number', scope: 'summary.labels')
     tr
       td =t('date_of_birth', scope: 'summary.labels')
       td =@summary.date_of_birth
-      td.right= link_to "Change", question_path(:dob)
+      td.right= link_to question_path(:dob) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('date_of_birth', scope: 'summary.labels').downcase
     tr
       td =t('personal', scope: 'summary.labels')
       td =@summary.full_name
-      td.right= link_to "Change", question_path(:personal_detail)
+      td.right= link_to question_path(:personal_detail) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('personal', scope: 'summary.labels').downcase
     tr
       td =t('address', scope: 'summary.labels')
       td =@summary.full_address
-      td.right= link_to "Change", question_path(:applicant_address)
+      td.right= link_to question_path(:applicant_address) do
+        | Change
+        span.visuallyhidden
+          | &nbsp;
+          =t('address', scope: 'summary.labels').downcase
     -if @summary.email_contact
       tr
         td =t('contact_email', scope: 'summary.labels')
         td =@summary.email_address
-        td.right= link_to "Change", question_path(:contact)
+        td.right= link_to question_path(:contact) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('contact_email', scope: 'summary.labels').downcase
     -else
       tr
         td = t('contact', scope: 'summary.labels')
         td = t('summary.contact_none')
-        td.right= link_to "Change", question_path(:contact)
+        td.right= link_to question_path(:contact) do
+          | Change
+          span.visuallyhidden
+            | &nbsp;
+            =t('contact', scope: 'summary.labels').downcase
 
 h2.heading-medium =t('heading', scope: 'summary.truth')
 p =t('statement', scope: 'summary.truth')

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -134,7 +134,7 @@ en:
       details:
         section_1: Enter the amount of money you get every month before any tax or National Insurance payments have been taken off.
         section_2: If you get paid weekly, multiply your weekly pay by 52, then divide it by 12. This will give you a monthly total.
-        section_3: There are some benefits you shouldn't include as income, see the full list and further information about completing this section in the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf">guide (EX160A) (PDF 440KB)</a>.
+        section_3: There are some benefits you shouldn't include as income, see the full list and further information about completing this section in <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf">the guide (EX160A) (PDF 440KB)</a>.
         section_4: You only need to fill in the fields that apply to you.
       labels:
         your_income: "Your monthly income"

--- a/config/locales/summary.yml
+++ b/config/locales/summary.yml
@@ -9,6 +9,7 @@ en:
       savings: 'Savings and investments'
       benefits: 'Benefits'
       children: 'Children'
+      income: 'Income'
       fee: 'Fee paid'
       probate: 'Probate case'
       deceased_name: 'Name of deceased'

--- a/spec/features/pages/summary_spec.rb
+++ b/spec/features/pages/summary_spec.rb
@@ -89,20 +89,20 @@ RSpec.feature 'As a user' do
     scenario 'the change links take me to the correct page' do
       given_user_provides_all_data
       visit '/summary'
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:marital_status)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:savings_and_investment)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:benefit)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:dependent)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:income)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:fee)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:probate)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:claim)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:form_name)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:dob)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:national_insurance)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:personal_detail)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:applicant_address)}']"
-      expect(page).to have_xpath "//a[.='Change'][@href='#{question_path(:contact)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:form_name)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:marital_status)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:savings_and_investment)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:benefit)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:dependent)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:income)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:fee)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:probate)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:claim)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:dob)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:national_insurance)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:personal_detail)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:applicant_address)}']"
+      expect(page).to have_xpath "//a[starts-with(text(), 'Change')][@href='#{question_path(:contact)}']"
     end
   end
 end


### PR DESCRIPTION
Add hidden text to the 'Change' links on the summary page, and lengthen links to 'the guide'.