### PR TITLE
add captions to tables

### DIFF
--- a/app/views/questions/forms/_income.html.slim
+++ b/app/views/questions/forms/_income.html.slim
@@ -4,6 +4,11 @@ legend.visuallyhidden = t('text', scope: @form.i18n_scope)
 
 .form-group
   table.income
+    caption.visuallyhidden
+      | Please enter details of your&nbsp;
+      -if married?
+        | and your partner's&nbsp;
+      | monthly income
     thead
       tr
         td &nbsp;

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -9,6 +9,7 @@ h1.heading-large
   =t('title', scope: 'summary.labels')
 
 table
+  caption.visuallyhidden Please check the details of your application for help with fees
   tbody
     tr
       td =t('form_name', scope: 'summary.labels')


### PR DESCRIPTION
[Pivotal mentions that the summary page table has no caption](https://www.pivotaltracker.com/story/show/121287999), as reported by DAC, so this provides one as well as one for the table on the income entry page.