### PR TITLE
Make homepage external

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,12 +3,18 @@ class SessionsController < ApplicationController
   # the page with the Start button that page will be managed by GOV.UK, so
   # we can't make it POST because of XSS restriction
   def start
-    storage.start
+    storage_with_clear.start
     redirect_to(question_path(QuestionFormFactory::IDS.first))
   end
 
   def destroy
-    storage.clear
+    storage_with_clear
     redirect_to(root_path)
+  end
+
+  private
+
+  def storage_with_clear
+    Storage.new(session, clear: true)
   end
 end

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -1,8 +1,9 @@
 class Storage
   class Expired < StandardError; end
 
-  def initialize(session)
+  def initialize(session, options = {})
     @session = session
+    clear if options[:clear]
     check_expiration!
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  root 'home#index'
+  if Settings.homepage.external_url
+    root to: redirect(Settings.homepage.external_url)
+  else
+    root 'home#index'
+  end
 
   get 'terms_and_conditions' => 'home#terms_and_conditions'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,5 @@ session:
 et:
   england_wales_email: ETHelpwithfees@hmcts.gsi.gov.uk
   scotland_email: GLASGOWET@hmcts.gsi.gov.uk
+homepage:
+  external_url: <%= ENV['HOMEPAGE_EXTERNAL_URL'] || nil %>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
+  let(:session) { double }
+  let(:storage) { double(start: nil) }
+
   before do
-    allow(controller).to receive(:storage).and_return(storage)
+    allow(controller).to receive(:session).and_return(session)
+    expect(Storage).to receive(:new).with(session, clear: true).and_return(storage)
   end
 
   describe 'GET #start' do
-    let(:storage) { double(start: nil) }
-
     before do
       get :start
     end
@@ -22,14 +24,8 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:storage) { double(clear: nil) }
-
     before do
       delete :destroy
-    end
-
-    it 'clears the storage' do
-      expect(storage).to have_received(:clear)
     end
 
     it 'redirects to the start page' do


### PR DESCRIPTION
* If an external url is set via ENV, home page is always redirected there (there's no test for this as it uses conditional routes and it doesn't seem to be easily possible with RSpec), better solution may be done later
* All data is cleared when `/session/start` is accessed (the apply button either from the homepage or the gov.uk page)