### PR TITLE
DAC amend for email notification

### DIFF
--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -220,6 +220,6 @@ en:
       title: 'Your email address'
       breadcrumb: 'Step 15 of 18'
       text: "What's your email address?"
-      details: "We can email you to confirm your application has been received."
+      details: "We will email you to confirm your application has been received."
       email_label: "Email address"
       feedback_opt_in: "Check this box if you're willing to share your experience of this service. A member of the team may contact you. We won't use your email address for anything else."


### PR DESCRIPTION
Change from ‘can’ to ‘will’ to meet DAC recommendations.