### PR TITLE
Update nokogiri gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'moj_template', '~> 0.23.2'
 gem 'sass-rails', '5.0.4'
 gem 'slim-rails'
 gem 'uglifier', '>= 1.3.0'
-
+gem 'nokogiri', '~> 1.6.8'
 gem 'unicorn'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,16 +132,18 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     moj_template (0.23.2)
       rails (>= 3.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     parser (2.3.0.6)
       ast (~> 2.2)
+    pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -300,6 +302,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   moj_template (~> 0.23.2)
+  nokogiri (~> 1.6.8)
   pry-rails
   rails (~> 4.2.6)
   rest-client
@@ -319,4 +322,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Help with fees - public facing app
-[![Code Climate](https://codeclimate.com/github/ministryofjustice/hwf-publicapp/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/hwf-publicapp) [![Test Coverage](https://codeclimate.com/github/ministryofjustice/hwf-publicapp/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/hwf-publicapp) [![Build Status](https://travis-ci.org/ministryofjustice/hwf-publicapp.svg?branch=master)](https://travis-ci.org/ministryofjustice/hwf-publicapp)
+[![Code Climate](https://codeclimate.com/github/ministryofjustice/hwf-publicapp/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/hwf-publicapp) [![Test Coverage](https://codeclimate.com/github/ministryofjustice/hwf-publicapp/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/hwf-publicapp) [![Build Status](https://travis-ci.org/ministryofjustice/hwf-publicapp.svg?branch=master)](https://travis-ci.org/ministryofjustice/hwf-publicapp) [![Dependency Status](https://gemnasium.com/badges/github.com/ministryofjustice/hwf-publicapp.svg)](https://gemnasium.com/github.com/ministryofjustice/hwf-publicapp)
 
 Help with fees app for public
 


### PR DESCRIPTION
Due to a code injection warning in [CVE-2015-8806](http://www.cvedetails.com/cve/CVE-2015-8806/)