### PR TITLE
unhighlight checkbox label when JS unchecks box

### DIFF
--- a/app/assets/javascripts/modules/form-name.js
+++ b/app/assets/javascripts/modules/form-name.js
@@ -28,7 +28,7 @@ window.moj.Modules.FormName = {
     var self = this;
 
     if (self.$identifier.val().length > 0 && self.$unknown.is(':checked')) {
-      self.$unknown.attr('checked', false);
+      self.$unknown.attr('checked', false).closest('label').removeClass('selected');
     }
   },
 


### PR DESCRIPTION
The "form name unknown" box is programatically unchecked when the user starts typing a form name or number. It should also remove the `selected` CSS class from the label.