### PR TITLE
update start page with expandable regions

### DIFF
--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -20,6 +20,9 @@
 .util_mt-0 {
   margin-top: 0 !important;
 }
+.util_mt-small {
+  margin-top: 15px !important;
+}
 .util_mt-medium {
   margin-top: 30px !important;
 }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,51 +1,81 @@
-h1.heading-xlarge.heading-with-lede Apply for help with fees
-p.lede You may not have to pay a court or tribunal fee, or you may get some money off.
+h1.heading-xlarge.heading-with-lede Apply for help with court and tribunal fees
+p.lede You may not have to pay a #{link_to 'court or tribunal fee', 'https://www.gov.uk/court-fees-what-they-are', class: 'external', rel: 'external'}, or you may get some money off.
 
-h2.heading-large You're eligible to apply if:
+.text
+  h2.heading-large To be eligible for help with fees, you need to show that:
 
-h3.heading-medium.util_mb-0 You're receiving one of these benefits
-ul.list.list-bullet
-  li Jobseeker's Allowance (JSA)
-  li Employment and Support Allowance (ESA)
-  li Income Support
-  li Universal Credit
-  li Pension Credit (Guarantee Credit)
-  li Scottish Civil Legal Aid
+  ol.list.list-number
+    li
+      | You (and your partner if you have one) have no savings or only a small amount
+      details.util_mt-small.util_mb-small
+        summary More about maximum savings amounts
+        .panel-indent
+          p In most cases you (and your partner if you have one) should have no savings or less than £3,000 in savings and investments if you’re under 61. If you’re 61 or over, you can have up to £16,000.
+          p Savings and investments don't include your main home, personal belongings, wages or benefits.
 
-h3.heading-medium.util_mb-0 You earn less than
-ul.list.list-bullet
-  li £1,085 a month before tax and National Insurance has been taken off (this can include benefits, eg working tax credit, child tax credit)
+    li
+      | And you’re <strong>either</strong> on benefits
+      details.util_mt-small.util_mb-small
+        summary There are 6 qualifying benefits
+        .panel-indent
+          h5 If you receive 1 of these benefits (and have a small amount of savings) you won't have to pay a fee:
+          ul.list.list-bullet
+            li Jobseeker’s Allowance (JSA)
+            li Employment and Support Allowance (ESA)
+            li Income Support
+            li Universal Credit
+            li Pension Credit (Guarantee Credit)
+            li Scottish Civil Legal Aid
 
-h3.heading-medium.util_mb-0 You have less than
-ul.list.list-bullet
-  li £3,000 in savings and investments
+    li
+      | <strong>or</strong> have a low income.
+      details.util_mt-small.util_mb-small
+        summary More about what qualifies as a low income
+        .panel-indent
+          p If you earn less a month than the amounts in the table below (before tax and National Insurance has been taken off) then you won't have to pay a fee. This can include benefits, eg working tax credit, child tax credit.
 
-h2.heading-large You should still apply if:
+          table.util_mb-medium
+            thead
+              tr
+                th Number of children
+                th If you're single
+                th If you have a partner
+            tbody
+              tr
+                td 0
+                td £1,085
+                td £1,245
+              tr
+                td 1
+                td £1,330
+                td £1,490
+              tr
+                td 2
+                td £1,575
+                td £1,735
 
-ul.list.list-bullet
-  li you (and your partner, if you have one) are over 61 and you have more than £3,000 in savings and investments
-  li your court fee is more than £1,000
-  li you earn more than £1,085 a month (before tax and National Insurance is taken off) and you have financially dependent children
+          p If you have 3 or more children there’s an extra allowance of £245 for each child.
 
-p See #{link_to 'the guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf', class: "external", rel: "external"} for detailed information about who is eligible to apply for help with fees.
+          p See the #{link_to 'guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf', class: 'external', rel: 'external'} for detailed information about who is eligible to apply for help with fees.
 
-h2.heading-large What you'll need:
-ul.list.list-bullet
-  li National Insurance number
-  li court or tribunal form name or number
-  li case, claim or ‘notice to pay’ number (if you have one)
-  li most recent bank statement for all current accounts
-  li most recent payslip (if you have one)
-  li most recent tax return (if you're self employed)
 
-p Applying takes around 10 minutes. This service is for England and Wales only.
+  h2.heading-large What you'll need:
+  ul.list.list-bullet
+    li National Insurance number
+    li court or tribunal form name or number
+    li case, claim or ‘notice to pay’ number (if you have one)
+    li most recent bank statement for all current accounts
+    li most recent payslip (if you have one)
+    li most recent tax return (if you're self employed)
 
-= link_to(t('start_application'), start_session_path, role: :button, class: 'button button-start')
+  p Applying takes around 10 minutes. This service is for England and Wales only.
 
-p.util_mt-large
-  strong.block.bold-small =t('session.note.heading')
-  strong.block
-    =t('session.note.text')
+  = link_to(t('start_application'), start_session_path, role: :button, class: 'button button-start')
 
-h2.heading-large Other ways to apply
-p You can also apply by post using the #{link_to 'help with fees form (EX160) (PDF 123KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf', class: 'external', rel: 'external'}.
+  p.util_mt-large
+    strong.block.bold-small =t('session.note.heading')
+    strong.block
+      =t('session.note.text')
+
+  h2.heading-large Other ways to apply
+  p You can also apply by post using the #{link_to 'help with fees form (EX160) (PDF 123KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf', class: 'external', rel: 'external'}.

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -68,7 +68,7 @@ p.lede You may not have to pay a #{link_to 'court or tribunal fee', 'https://www
     li most recent payslip (if you have one)
     li most recent tax return (if you're self employed)
 
-  p Applying takes around 10 minutes. This service is for England and Wales only.
+  p Applying takes around 10 minutes. You only see questions relevant to your situation so you may skip steps. This service is for England and Wales only.
 
   = link_to(t('start_application'), start_session_path, role: :button, class: 'button button-start')
 

--- a/spec/features/can_user_apply_for_help_with_fees_spec.rb
+++ b/spec/features/can_user_apply_for_help_with_fees_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'As a user' do
 
-  let(:conditions_of_application) { "You're receiving one of these benefits" }
+  let(:conditions_of_application) { "And you’re either on benefits" }
 
   scenario 'I want to learn if I can apply for "Help with fees"' do
     visit '/'

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -95,7 +95,7 @@ module FeatureSteps
   alias then_their_data_is_deleted then_their_data_is_not_persisted
 
   def then_they_are_redirected_to_homepage_with_expiry_message
-    expect(page).to have_text 'Apply for help with fees'
+    expect(page).to have_text 'Apply for help with court and tribunal fees'
     expect(page).to have_text "You didn't enter any information for more than 10 minutes so you need to start your application again."
   end
 


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/121658901)

Even though the live version of this page will be outside the live app, it's still good to have it here as a record. There is some debate about whether GDS can use the `<details>` expandable elements in their templates.

![screen shot 2016-06-30 at 16 42 32](https://cloud.githubusercontent.com/assets/988436/16494560/aeed180c-3ee1-11e6-928f-cb0a6d85bb89.png)

