### PR TITLE
row headers for summary table

### DIFF
--- a/app/assets/stylesheets/local/tables.scss
+++ b/app/assets/stylesheets/local/tables.scss
@@ -27,3 +27,11 @@ table.income {
     }
   }
 }
+
+table.summary {
+  tbody {
+    th {
+      font-weight: normal;
+    }
+  }
+}

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -8,7 +8,7 @@ h1.heading-large
     | :&nbsp;
   =t('title', scope: 'summary.labels')
 
-table
+table.summary
   caption.visuallyhidden Please check the details of your application for help with fees
   tbody
     tr

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -12,7 +12,7 @@ table
   caption.visuallyhidden Please check the details of your application for help with fees
   tbody
     tr
-      td =t('form_name', scope: 'summary.labels')
+      th scope="row" =t('form_name', scope: 'summary.labels')
       td=@summary.form_name
       td.right= link_to question_path(:form_name) do
         | Change
@@ -20,7 +20,7 @@ table
           | &nbsp;
           =t('form_name', scope: 'summary.labels').downcase
     tr
-      td =t('married', scope: 'summary.labels')
+      th scope="row" =t('married', scope: 'summary.labels')
       td= t("marital_status_#{@summary.married}", scope: 'summary')
       td.right= link_to question_path(:marital_status) do
         | Change
@@ -28,7 +28,7 @@ table
           | &nbsp;
           =t('married', scope: 'summary.labels').downcase
     tr
-      td =t('savings', scope: 'summary.labels')
+      th scope="row" =t('savings', scope: 'summary.labels')
       td= @summary.savings
       td.right= link_to question_path(:savings_and_investment) do
         | Change
@@ -36,7 +36,7 @@ table
           | &nbsp;
           =t('savings', scope: 'summary.labels').downcase
     tr
-      td =t('benefits', scope: 'summary.labels')
+      th scope="row" =t('benefits', scope: 'summary.labels')
       td= t("applicant_on_benefits_#{@summary.benefits}", scope: 'summary')
       td.right= link_to question_path(:benefit) do
         | Change
@@ -45,7 +45,7 @@ table
           =t('benefits', scope: 'summary.labels').downcase
     - if @summary.children_text
       tr
-        td =t('children', scope: 'summary.labels')
+        th scope="row" =t('children', scope: 'summary.labels')
         td =@summary.children_text
         td.right= link_to question_path(:dependent) do
           | Change
@@ -54,7 +54,7 @@ table
             =t('children', scope: 'summary.labels').downcase
     - if @summary.income
       tr
-        td =t('income', scope: 'summary.labels')
+        th scope="row" =t('income', scope: 'summary.labels')
         td =number_to_currency(@summary.income, precision: 2, unit: '£')
         td.right= link_to question_path(:income) do
           | Change
@@ -62,7 +62,7 @@ table
             | &nbsp;
             =t('income', scope: 'summary.labels').downcase
     tr
-      td =t('fee', scope: 'summary.labels')
+      th scope="row" =t('fee', scope: 'summary.labels')
       td =@summary.refund_text
       td.right= link_to question_path(:fee) do
         | Change
@@ -71,7 +71,7 @@ table
           =t('fee', scope: 'summary.labels').downcase
     -if @summary.probate
       tr
-        td = t('deceased_name', scope: 'summary.labels')
+        th scope="row" = t('deceased_name', scope: 'summary.labels')
         td =@summary.deceased_name
         td.right= link_to question_path(:probate) do
           | Change
@@ -79,7 +79,7 @@ table
             | &nbsp;
             =t('deceased_name', scope: 'summary.labels').downcase
       tr
-        td = t('date_of_death', scope: 'summary.labels')
+        th scope="row" = t('date_of_death', scope: 'summary.labels')
         td =@summary.date_of_death
         td.right= link_to question_path(:probate) do
           | Change
@@ -88,15 +88,15 @@ table
             =t('date_of_death', scope: 'summary.labels').downcase
     -else
       tr
-        td =t('probate', scope: 'summary.labels')
-        td=t("probate_case_#{@summary.probate}", scope: 'summary')
+        th scope="row" =t('probate', scope: 'summary.labels')
+        td =t("probate_case_#{@summary.probate}", scope: 'summary')
         td.right= link_to question_path(:probate) do
           | Change
           span.visuallyhidden
             | &nbsp;
             =t('probate', scope: 'summary.labels').downcase
     tr
-      td =t('claim', scope: 'summary.labels')
+      th scope="row" =t('claim', scope: 'summary.labels')
       td =t("claim_number_#{@summary.case_number?}", scope: 'summary')
       td.right= link_to question_path(:claim) do
         | Change
@@ -104,7 +104,7 @@ table
           | &nbsp;
           =t('claim', scope: 'summary.labels').downcase
     tr
-      td =t('ni_number', scope: 'summary.labels')
+      th scope="row" =t('ni_number', scope: 'summary.labels')
       td =@summary.ni_number
       td.right= link_to question_path(:national_insurance) do
         | Change
@@ -112,7 +112,7 @@ table
           | &nbsp;
           =t('ni_number', scope: 'summary.labels')
     tr
-      td =t('date_of_birth', scope: 'summary.labels')
+      th scope="row" =t('date_of_birth', scope: 'summary.labels')
       td =@summary.date_of_birth
       td.right= link_to question_path(:dob) do
         | Change
@@ -120,7 +120,7 @@ table
           | &nbsp;
           =t('date_of_birth', scope: 'summary.labels').downcase
     tr
-      td =t('personal', scope: 'summary.labels')
+      th scope="row" =t('personal', scope: 'summary.labels')
       td =@summary.full_name
       td.right= link_to question_path(:personal_detail) do
         | Change
@@ -128,7 +128,7 @@ table
           | &nbsp;
           =t('personal', scope: 'summary.labels').downcase
     tr
-      td =t('address', scope: 'summary.labels')
+      th scope="row" =t('address', scope: 'summary.labels')
       td =@summary.full_address
       td.right= link_to question_path(:applicant_address) do
         | Change
@@ -137,7 +137,7 @@ table
           =t('address', scope: 'summary.labels').downcase
     -if @summary.email_contact
       tr
-        td =t('contact_email', scope: 'summary.labels')
+        th scope="row" =t('contact_email', scope: 'summary.labels')
         td =@summary.email_address
         td.right= link_to question_path(:contact) do
           | Change
@@ -146,7 +146,7 @@ table
             =t('contact_email', scope: 'summary.labels').downcase
     -else
       tr
-        td = t('contact', scope: 'summary.labels')
+        th scope="row" = t('contact', scope: 'summary.labels')
         td = t('summary.contact_none')
         td.right= link_to question_path(:contact) do
           | Change


### PR DESCRIPTION
[Pivotal - DAC recommendation](https://www.pivotaltracker.com/story/show/123104281)

Changes the first `td` in each row of the check details table to `th scope="row"` in order to give structure to the table, as recommended by DAC. 