### PR TITLE
Remove visually hidden full stops

### DIFF
--- a/app/views/questions/forms/_fee.html.slim
+++ b/app/views/questions/forms/_fee.html.slim
@@ -15,6 +15,5 @@ legend.visuallyhidden = t('text', scope: @form.i18n_scope)
       - if @form.errors[:date_paid].any?
         span.error-message#date_paid = @form.errors[:date_paid].join(' ')
       = f.label :date_paid, class: 'form-label'
-      span.visuallyhidden .
       .hint = t('hint_html', scope: @form.i18n_scope)
       = f.text_field :date_paid, class: 'form-control'

--- a/app/views/questions/forms/_probate.html.slim
+++ b/app/views/questions/forms/_probate.html.slim
@@ -20,6 +20,5 @@ legend.visuallyhidden= t('text', scope: @form.i18n_scope)
       - if @form.errors[:date_of_death].any?
         span.error-message#date_of_death = @form.errors[:date_of_death].join(' ')
       = f.label :date_of_death, class: 'form-label'
-      span.visuallyhidden .
       .hint = t('hint_html', scope: @form.i18n_scope)
       = f.text_field :date_of_death, class: 'form-control'


### PR DESCRIPTION
[Pivotal - DAC recommendation](https://www.pivotaltracker.com/story/show/123080931)

We introduced visually hidden full stops to prevent screen readers running sentences together in input labels. It transpires that this just sticks out as an error to real screen reader users. They are used to sentences with little separation between them, and this extra element intended to help them in fact just looks like it shouldn't be there.

