### PR TITLE
Fix broken links to PDFs

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -56,7 +56,7 @@ p.lede You may not have to pay a #{link_to 'court or tribunal fee', 'https://www
 
           p If you have 3 or more children there’s an extra allowance of £245 for each child.
 
-          p See the #{link_to 'guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf', class: 'external', rel: 'external'} for detailed information about who is eligible to apply for help with fees.
+          p See the #{link_to 'guide (EX160A) (PDF 440KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng.pdf', class: 'external', rel: 'external'} for detailed information about who is eligible to apply for help with fees.
 
 
   h2.heading-large What you'll need:
@@ -78,4 +78,4 @@ p.lede You may not have to pay a #{link_to 'court or tribunal fee', 'https://www
       =t('session.note.text')
 
   h2.heading-large Other ways to apply
-  p You can also apply by post using the #{link_to 'help with fees form (EX160) (PDF 123KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf', class: 'external', rel: 'external'}.
+  p You can also apply by post using the #{link_to 'help with fees form (EX160) (PDF 123KB)', 'http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng.pdf', class: 'external', rel: 'external'}.

--- a/config/locales/questions.yml
+++ b/config/locales/questions.yml
@@ -111,7 +111,7 @@ en:
             name: 'Contribution-based Job Seekers Allowance'
             hint: '(JSA)'
           item_2:
-            name: 'Contribution-based Employment Support Allowance'
+            name: 'Contribution-based Employment and Support Allowance'
             hint: '(ESA)'
           item_3:
             name: 'Pension Credit and Savings Credit'
@@ -147,7 +147,7 @@ en:
       details:
         section_1: Enter the amount of money you get every month before any tax or National Insurance payments have been taken off.
         section_2: If you get paid weekly, multiply your weekly pay by 52, then divide it by 12. This will give you a monthly total.
-        section_3: There are some benefits you shouldn't include as income, see the full list and further information about completing this section in <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng-20160212.pdf">the guide (EX160A) (PDF 440KB)</a>.
+        section_3: There are some benefits you shouldn't include as income, see the full list and further information about completing this section in <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160a-eng.pdf">the guide (EX160A) (PDF 440KB)</a>.
         section_4: You only need to fill in the fields that apply to you.
       labels:
         your_income: "Your monthly income"

--- a/public/400.html
+++ b/public/400.html
@@ -68,7 +68,7 @@
       </header>
       <p class="lead"><strong>Sorry, an error has occurred.</strong></p>
       <p>Please return to the <a href="/">help with fees homepage</a> and try again.</p>
-      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
+      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
     </section>
   </div>
 

--- a/public/404.html
+++ b/public/404.html
@@ -69,7 +69,7 @@
       <p class="lead"><strong>Sorry, this page does not exist.</strong></p>
       <p>If you entered a web address, please check it’s correct.</p>
       <p>To find out more or apply, please go to the <a href="/">help with fees homepage</a>.</p>
-      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
+      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
     </section>
   </div>
 

--- a/public/500.html
+++ b/public/500.html
@@ -68,7 +68,7 @@
       </header>
       <p class="lead"><strong>Sorry, something went wrong.</strong></p>
       <p>Please return to the <a href="/">help with fees homepage</a> and try again.</p>
-      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng-20160212.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
+      <p>If the problem persists or you need help urgently, you can download and complete the <a class="external" rel="external" href="http://s3-eu-west-1.amazonaws.com/hmctsformfinder/ex160-eng.pdf">help with fees form (EX160) (PDF 123KB)</a>.</p>
     </section>
   </div>
 


### PR DESCRIPTION
Start page
— links to guide and form
Benefits
— small typo on benefit name
Income
— link to guide
400 / 404 /500
— link to form