### PR TITLE
Only use <fieldset>s where appropriate

### DIFF
--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -14,12 +14,10 @@ h1.heading-large
   =render("questions/headers/#{@form.id}")
 
 = form_for @form, as: @form.id, url: question_path(@question), html: { autocomplete: @form.autocomplete, method: :put } do |f|
-  fieldset
+  =render("questions/forms/#{@form.id}", f: f)
 
-    =render("questions/forms/#{@form.id}", f: f)
-
-    .form-group
-      = f.submit t('submit_button'), class: 'button'
+  .form-group
+    = f.submit t('submit_button'), class: 'button'
 .text
   p
     strong.block.bold-small =t('session.note.heading')

--- a/app/views/questions/forms/_applicant_address.html.slim
+++ b/app/views/questions/forms/_applicant_address.html.slim
@@ -1,12 +1,12 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
-.form-group class=('error' if @form.errors[:address].any?)
-  = f.label :address, class: 'form-label'
-  - if @form.errors[:address].any?
-    span.error-message#address = @form.errors[:address].join(' ')
-  = f.text_area :address, class: 'form-control', rows: 6
-.form-group class=('error' if @form.errors[:postcode].any?)
-  = f.label :postcode, class: 'form-label'
-  - if @form.errors[:postcode].any?
-    span.error-message#postcode = @form.errors[:postcode].join(' ')
-  = f.text_field :postcode, class: 'form-control  js-uppercase'
+fieldset
+  legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+  .form-group class=('error' if @form.errors[:address].any?)
+    = f.label :address, class: 'form-label'
+    - if @form.errors[:address].any?
+      span.error-message#address = @form.errors[:address].join(' ')
+    = f.text_area :address, class: 'form-control', rows: 6
+  .form-group class=('error' if @form.errors[:postcode].any?)
+    = f.label :postcode, class: 'form-label'
+    - if @form.errors[:postcode].any?
+      span.error-message#postcode = @form.errors[:postcode].join(' ')
+    = f.text_field :postcode, class: 'form-control  js-uppercase'

--- a/app/views/questions/forms/_benefit.html.slim
+++ b/app/views/questions/forms/_benefit.html.slim
@@ -1,15 +1,15 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors.any?)
   = f.hidden_field :on_benefits, value: nil
   - if @form.errors.any?
     span.error-message#on_benefits = @form.errors[:on_benefits].join(' ')
-  label.block-label for='benefit_on_benefits_false'
-    = f.radio_button :on_benefits, 'false'
-    = t('on_benefits_false', scope: @form.i18n_scope)
-  label.block-label for='benefit_on_benefits_true'
-    = f.radio_button :on_benefits, 'true'
-    = t('on_benefits_true', scope: @form.i18n_scope)
+  fieldset
+    legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+    label.block-label for='benefit_on_benefits_false'
+      = f.radio_button :on_benefits, 'false'
+      = t('on_benefits_false', scope: @form.i18n_scope)
+    label.block-label for='benefit_on_benefits_true'
+      = f.radio_button :on_benefits, 'true'
+      = t('on_benefits_true', scope: @form.i18n_scope)
 
 .form-group
   details

--- a/app/views/questions/forms/_contact.html.slim
+++ b/app/views/questions/forms/_contact.html.slim
@@ -1,18 +1,18 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group
   p = t('details', scope: @form.i18n_scope)
 
-.form-group.optional.util_mb-0 class=('error' if @form.errors[:email].any?)
-  - if @form.errors[:email].any?
-    span.error-message#email = @form.errors[:email].join(' ')
-  = f.label :email, t('email_label', scope: @form.i18n_scope), class: 'form-label'
-  .hint
-    | (Optional)
-  = f.text_field :email, type: 'email', class: 'form-control'
+fieldset
+  legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+  .form-group.optional.util_mb-0 class=('error' if @form.errors[:email].any?)
+    - if @form.errors[:email].any?
+      span.error-message#email = @form.errors[:email].join(' ')
+    = f.label :email, t('email_label', scope: @form.i18n_scope), class: 'form-label'
+    .hint
+      | (Optional)
+    = f.text_field :email, type: 'email', class: 'form-control'
 
-.form-group
-  .text
-    label.form-checkbox
-      = f.check_box :feedback_opt_in
-      span = t('feedback_opt_in', scope: @form.i18n_scope)
+  .form-group
+    .text
+      label.form-checkbox
+        = f.check_box :feedback_opt_in
+        span = t('feedback_opt_in', scope: @form.i18n_scope)

--- a/app/views/questions/forms/_dependent.html.slim
+++ b/app/views/questions/forms/_dependent.html.slim
@@ -1,20 +1,20 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors[:children].any?)
   - if @form.errors[:children].any?
     span.error-message#dependents = @form.errors[:children].join(' ')
-  label.block-label for='dependent_children_false'
-    = f.radio_button :children, 'false'
-    = t('children_false', scope: @form.i18n_scope)
-  label.block-label for='dependent_children_true' data-target='dependent-children_number-panel'
-    = f.radio_button :children, 'true'
-    = t('children_true', scope: @form.i18n_scope)
-  #dependent-children_number-panel.panel-indent.util_mb-medium.js-hidden
-    .form-group class=('error' if @form.errors[:children_number].any?)
-      - if @form.errors[:children_number].any?
-        span.error-message#children_number = @form.errors[:children_number].join(' ')
-      = f.label :children_number, class: 'form-label'
-      = f.text_field :children_number, type: 'number', class: 'form-control'
+  fieldset
+    legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+    label.block-label for='dependent_children_false'
+      = f.radio_button :children, 'false'
+      = t('children_false', scope: @form.i18n_scope)
+    label.block-label for='dependent_children_true' data-target='dependent-children_number-panel'
+      = f.radio_button :children, 'true'
+      = t('children_true', scope: @form.i18n_scope)
+    #dependent-children_number-panel.panel-indent.util_mb-medium.js-hidden
+      .form-group class=('error' if @form.errors[:children_number].any?)
+        - if @form.errors[:children_number].any?
+          span.error-message#children_number = @form.errors[:children_number].join(' ')
+        = f.label :children_number, class: 'form-label'
+        = f.text_field :children_number, type: 'number', class: 'form-control'
 
 .form-group
   details

--- a/app/views/questions/forms/_dob.html.slim
+++ b/app/views/questions/forms/_dob.html.slim
@@ -1,5 +1,4 @@
-legend.visuallyhidden =t('text', scope: @form.i18n_scope)
-.form-group  class=('error' if @form.errors.any?)
+.form-group class=('error' if @form.errors.any?)
   label.form-label for='dob_date_of_birth'
     span.visuallyhidden =t('date_of_birth', scope: @form.i18n_scope)
     span.hint = t('hint_html', scope: @form.i18n_scope)

--- a/app/views/questions/forms/_fee.html.slim
+++ b/app/views/questions/forms/_fee.html.slim
@@ -1,19 +1,19 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors[:paid].any?)
   = f.hidden_field :paid, value: nil
   - if @form.errors[:paid].any?
     span.error-message#paid = @form.errors[:paid].join(' ')
-  label.block-label for='fee_paid_false'
-    = f.radio_button :paid, 'false'
-    = t('fee_paid_false', scope: @form.i18n_scope)
-  label.block-label for='fee_paid_true' data-target='date-fee-paid-panel'
-    = f.radio_button :paid, 'true'
-    = t('fee_paid_true', scope: @form.i18n_scope)
-  #date-fee-paid-panel.panel-indent.util_mb-medium.js-hidden
-    .form-group class=('error' if @form.errors[:date_paid].any?)
-      - if @form.errors[:date_paid].any?
-        span.error-message#date_paid = @form.errors[:date_paid].join(' ')
-      = f.label :date_paid, class: 'form-label'
-      .hint = t('hint_html', scope: @form.i18n_scope)
-      = f.text_field :date_paid, class: 'form-control'
+  fieldset
+    legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+    label.block-label for='fee_paid_false'
+      = f.radio_button :paid, 'false'
+      = t('fee_paid_false', scope: @form.i18n_scope)
+    label.block-label for='fee_paid_true' data-target='date-fee-paid-panel'
+      = f.radio_button :paid, 'true'
+      = t('fee_paid_true', scope: @form.i18n_scope)
+    #date-fee-paid-panel.panel-indent.util_mb-medium.js-hidden
+      .form-group class=('error' if @form.errors[:date_paid].any?)
+        - if @form.errors[:date_paid].any?
+          span.error-message#date_paid = @form.errors[:date_paid].join(' ')
+        = f.label :date_paid, class: 'form-label'
+        .hint = t('hint_html', scope: @form.i18n_scope)
+        = f.text_field :date_paid, class: 'form-control'

--- a/app/views/questions/forms/_form_name.html.slim
+++ b/app/views/questions/forms/_form_name.html.slim
@@ -1,5 +1,3 @@
-legend.visuallyhidden =t('text', scope: @form.i18n_scope)
-
 .form-group  class=('error' if @form.errors.any?)
   - if @form.errors[:identifier].any?
     span.error-message#identifier = @form.errors[:identifier].join(' ')

--- a/app/views/questions/forms/_marital_status.html.slim
+++ b/app/views/questions/forms/_marital_status.html.slim
@@ -1,16 +1,16 @@
-legend.visuallyhidden =t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors.any?)
   = f.hidden_field :married, value: nil
   - if @form.errors.any?
     span.error-message#married = @form.errors[:married].join(' ')
-  label.block-label for="marital_status_married_false"
-    = f.radio_button :married, 'false'
-    = t('married_false', scope: @form.i18n_scope)
+  fieldset
+    legend.visuallyhidden =t('text', scope: @form.i18n_scope)
+    label.block-label for="marital_status_married_false"
+      = f.radio_button :married, 'false'
+      = t('married_false', scope: @form.i18n_scope)
 
-  label.block-label for="marital_status_married_true"
-    = f.radio_button :married, 'true'
-    = t('married_true', scope: @form.i18n_scope)
+    label.block-label for="marital_status_married_true"
+      = f.radio_button :married, 'true'
+      = t('married_true', scope: @form.i18n_scope)
 
 .form-group
   details

--- a/app/views/questions/forms/_national_insurance.html.slim
+++ b/app/views/questions/forms/_national_insurance.html.slim
@@ -1,5 +1,3 @@
-legend.visuallyhidden =t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors.any?)
   label.form-label for='national_insurance_number'
     span.visuallyhidden =t('prompt', scope: @form.i18n_scope)

--- a/app/views/questions/forms/_personal_detail.html.slim
+++ b/app/views/questions/forms/_personal_detail.html.slim
@@ -1,19 +1,19 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
-.form-group.optional class=('error' if @form.errors[:title].any?)
-  = f.label :title, class: 'form-label'
-  .hint
-    | (Optional)
-  - if @form.errors[:title].any?
-    span.error-message#title = @form.errors[:title].join(' ')
-  = f.text_field :title, class: 'form-control form-control-smaller'
-.form-group class=('error' if @form.errors[:first_name].any?)
-  = f.label :first_name, class: 'form-label'
-  - if @form.errors[:first_name].any?
-    span.error-message#first_name = @form.errors[:first_name].join(' ')
-  = f.text_field :first_name, class: 'form-control'
-.form-group class=('error' if @form.errors[:last_name].any?)
-  = f.label :last_name, class: 'form-label'
-  - if @form.errors[:last_name].any?
-    span.error-message#last_name = @form.errors[:last_name].join(' ')
-  = f.text_field :last_name, class: 'form-control'
+fieldset
+  legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+  .form-group.optional class=('error' if @form.errors[:title].any?)
+    = f.label :title, class: 'form-label'
+    .hint
+      | (Optional)
+    - if @form.errors[:title].any?
+      span.error-message#title = @form.errors[:title].join(' ')
+    = f.text_field :title, class: 'form-control form-control-smaller'
+  .form-group class=('error' if @form.errors[:first_name].any?)
+    = f.label :first_name, class: 'form-label'
+    - if @form.errors[:first_name].any?
+      span.error-message#first_name = @form.errors[:first_name].join(' ')
+    = f.text_field :first_name, class: 'form-control'
+  .form-group class=('error' if @form.errors[:last_name].any?)
+    = f.label :last_name, class: 'form-label'
+    - if @form.errors[:last_name].any?
+      span.error-message#last_name = @form.errors[:last_name].join(' ')
+    = f.text_field :last_name, class: 'form-control'

--- a/app/views/questions/forms/_probate.html.slim
+++ b/app/views/questions/forms/_probate.html.slim
@@ -1,24 +1,24 @@
-legend.visuallyhidden= t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors[:kase].any?)
   = f.hidden_field :kase, value: nil
   - if @form.errors.any?
     span.error-message#kase = @form.errors[:kase].join(' ')
-  label.block-label for='probate_kase_false'
-    = f.radio_button :kase, 'false'
-    = t('probate_case_false', scope: @form.i18n_scope)
-  label.block-label for='probate_kase_true' data-target='probate-details-panel'
-    = f.radio_button :kase, 'true'
-    = t('probate_case_true', scope: @form.i18n_scope)
-  #probate-details-panel.panel-indent.util_mb-medium.js-hidden
-    .form-group class=('error' if @form.errors[:deceased_name].any?)
-      - if @form.errors[:deceased_name].any?
-        span.error-message#deceased_name = @form.errors[:deceased_name].join(' ')
-      = f.label :deceased_name, class: 'form-label'
-      = f.text_field :deceased_name, class: 'form-control'
-    .form-group class=('error' if @form.errors[:date_of_death].any?)
-      - if @form.errors[:date_of_death].any?
-        span.error-message#date_of_death = @form.errors[:date_of_death].join(' ')
-      = f.label :date_of_death, class: 'form-label'
-      .hint = t('hint_html', scope: @form.i18n_scope)
-      = f.text_field :date_of_death, class: 'form-control'
+  fieldset
+    legend.visuallyhidden= t('text', scope: @form.i18n_scope)
+    label.block-label for='probate_kase_false'
+      = f.radio_button :kase, 'false'
+      = t('probate_case_false', scope: @form.i18n_scope)
+    label.block-label for='probate_kase_true' data-target='probate-details-panel'
+      = f.radio_button :kase, 'true'
+      = t('probate_case_true', scope: @form.i18n_scope)
+    #probate-details-panel.panel-indent.util_mb-medium.js-hidden
+      .form-group class=('error' if @form.errors[:deceased_name].any?)
+        - if @form.errors[:deceased_name].any?
+          span.error-message#deceased_name = @form.errors[:deceased_name].join(' ')
+        = f.label :deceased_name, class: 'form-label'
+        = f.text_field :deceased_name, class: 'form-control'
+      .form-group class=('error' if @form.errors[:date_of_death].any?)
+        - if @form.errors[:date_of_death].any?
+          span.error-message#date_of_death = @form.errors[:date_of_death].join(' ')
+        = f.label :date_of_death, class: 'form-label'
+        .hint = t('hint_html', scope: @form.i18n_scope)
+        = f.text_field :date_of_death, class: 'form-control'

--- a/app/views/questions/forms/_savings_and_investment.html.slim
+++ b/app/views/questions/forms/_savings_and_investment.html.slim
@@ -1,20 +1,20 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors.any?)
   = f.hidden_field :choice, value: nil
   - if @form.errors.any?
     span.error-message#choice = @form.errors[:choice].join(' ')
-  label.block-label for='savings_and_investment_choice_less'
-    = f.radio_button :choice, :less
-    = t('less', scope: @form.i18n_scope)
+  fieldset
+    legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+    label.block-label for='savings_and_investment_choice_less'
+      = f.radio_button :choice, :less
+      = t('less', scope: @form.i18n_scope)
 
-  label.block-label for='savings_and_investment_choice_between'
-    = f.radio_button :choice, :between
-    = t('between', scope: @form.i18n_scope)
+    label.block-label for='savings_and_investment_choice_between'
+      = f.radio_button :choice, :between
+      = t('between', scope: @form.i18n_scope)
 
-  label.block-label for='savings_and_investment_choice_more'
-    = f.radio_button :choice, :more
-    = t('more', scope: @form.i18n_scope)
+    label.block-label for='savings_and_investment_choice_more'
+      = f.radio_button :choice, :more
+      = t('more', scope: @form.i18n_scope)
 
 .form-group
   details

--- a/app/views/questions/forms/_savings_and_investment_extra.html.slim
+++ b/app/views/questions/forms/_savings_and_investment_extra.html.slim
@@ -1,23 +1,23 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors[:over_61].any?)
   = f.hidden_field :over_61, value: nil
   - if @form.errors[:over_61].any?
     span.error-message#over_61 = @form.errors[:over_61].join(' ')
-  label.block-label for='savings_and_investment_extra_over_61_true'
-    = f.radio_button :over_61, 'true'
-    = t('over_61_true', scope: @form.i18n_scope)
-  label.block-label for='savings_and_investment_extra_over_61_false' data-target='amount-panel'
-    = f.radio_button :over_61, 'false'
-    = t('over_61_false', scope: @form.i18n_scope)
-  #amount-panel.panel-indent.util_mb-medium.js-hidden
-    .form-group class=('error' if @form.errors[:amount].any?)
-      - if @form.errors[:amount].any?
-        span.error-message#date_paid = @form.errors[:amount].join(' ')
-      = f.label :amount, class: 'form-label text' do
-        - if @online_application.married?
-          =t('amount_married', scope: @form.i18n_scope)
-        - else
-          =t('amount_single', scope: @form.i18n_scope)
-      span.currency £
-      = f.text_field :amount, class: 'form-control form-control-smaller'
+  fieldset
+    legend.visuallyhidden = t('text', scope: @form.i18n_scope)
+    label.block-label for='savings_and_investment_extra_over_61_true'
+      = f.radio_button :over_61, 'true'
+      = t('over_61_true', scope: @form.i18n_scope)
+    label.block-label for='savings_and_investment_extra_over_61_false' data-target='amount-panel'
+      = f.radio_button :over_61, 'false'
+      = t('over_61_false', scope: @form.i18n_scope)
+    #amount-panel.panel-indent.util_mb-medium.js-hidden
+      .form-group class=('error' if @form.errors[:amount].any?)
+        - if @form.errors[:amount].any?
+          span.error-message#date_paid = @form.errors[:amount].join(' ')
+        = f.label :amount, class: 'form-label text' do
+          - if @online_application.married?
+            =t('amount_married', scope: @form.i18n_scope)
+          - else
+            =t('amount_single', scope: @form.i18n_scope)
+        span.currency £
+        = f.text_field :amount, class: 'form-control form-control-smaller'

--- a/app/views/questions/forms/claim/_default.html.slim
+++ b/app/views/questions/forms/claim/_default.html.slim
@@ -1,22 +1,22 @@
-legend.visuallyhidden = t('hidden_legend', scope: @form.i18n_scope)
-
 .form-group class=('error' if @form.errors[:number].any?)
   = f.hidden_field :number, value: nil
   - if @form.errors[:number].any?
     span.error-message#kase = @form.errors[:number].join(' ')
-  label.block-label for='claim_default_number_false'
-    = f.radio_button :number, 'false'
-    = t('number_false', scope: @form.i18n_scope)
-  label.block-label for='claim_default_number_true' data-target='claim-identifier-panel'
-    = f.radio_button :number, 'true'
-    = t('number_true', scope: @form.i18n_scope)
-  #claim-identifier-panel.panel-indent.util_mb-medium.js-hidden
-    .form-group class=('error' if @form.errors[:identifier].any?)
-      - if @form.errors[:identifier].any?
-        span.error-message#identifier = @form.errors[:identifier].join(' ')
-      label.form-label(for='claim_default_identifier')
-        = t('identifier', scope: @form.i18n_scope)
-      = f.text_field :identifier, class: 'form-control'
+  fieldset
+    legend.visuallyhidden = t('hidden_legend', scope: @form.i18n_scope)
+    label.block-label for='claim_default_number_false'
+      = f.radio_button :number, 'false'
+      = t('number_false', scope: @form.i18n_scope)
+    label.block-label for='claim_default_number_true' data-target='claim-identifier-panel'
+      = f.radio_button :number, 'true'
+      = t('number_true', scope: @form.i18n_scope)
+    #claim-identifier-panel.panel-indent.util_mb-medium.js-hidden
+      .form-group class=('error' if @form.errors[:identifier].any?)
+        - if @form.errors[:identifier].any?
+          span.error-message#identifier = @form.errors[:identifier].join(' ')
+        label.form-label(for='claim_default_identifier')
+          = t('identifier', scope: @form.i18n_scope)
+        = f.text_field :identifier, class: 'form-control'
 
 .form-group
   details

--- a/app/views/questions/forms/claim/_et.html.slim
+++ b/app/views/questions/forms/claim/_et.html.slim
@@ -1,5 +1,3 @@
-legend.visuallyhidden = t('hidden_legend', scope: @form.i18n_scope)
-
 .form-group  class=('error' if @form.errors.any?)
   = f.label :identifier, class: 'form-label'
   - if @form.errors[:identifier].any?


### PR DESCRIPTION
[Pivotal - DAC recommendation](https://www.pivotaltracker.com/story/show/121582181)
[Second pivotal ticket covered by this PR](https://www.pivotaltracker.com/story/show/121581909)

We were blanket enclosing all form fields groups in a fieldset with a legend per page. The fieldset tag is only meant for grouping related form controls, so in cases where there is only a single input box no fieldset is needed, and in other cases the fieldset should only enclose groupe/related fields.