### PR TITLE
Done page

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -6,19 +6,16 @@ class ConfirmationsController < ApplicationController
 
   def done
     prepare_view
-    clear_storage
   end
 
   def refund
     prepare_view
     build_ga_event
-    clear_storage
   end
 
   def et
     prepare_view
     build_ga_event
-    clear_storage
   end
 
   private
@@ -26,10 +23,6 @@ class ConfirmationsController < ApplicationController
   def prepare_view
     @online_application = online_application
     @result = storage.submission_result
-  end
-
-  def clear_storage
-    storage.clear
   end
 
   def build_ga_event

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,11 @@ class SessionsController < ApplicationController
     redirect_to(question_path(QuestionFormFactory::IDS.first))
   end
 
+  def finish
+    storage.clear
+    redirect_to(root_path)
+  end
+
   def destroy
     storage_with_clear
     redirect_to(root_path)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,8 @@ class SessionsController < ApplicationController
 
   def finish
     storage.clear
-    redirect_to(root_path)
+    redirect_path = Settings.done_page.external_url || root_path
+    redirect_to(redirect_path)
   end
 
   def destroy

--- a/app/views/confirmations/_footer.html.slim
+++ b/app/views/confirmations/_footer.html.slim
@@ -1,4 +1,5 @@
 .js-only.no-print
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')
 
-p.util_mt-large.no-print =link_to(t('confirmation.back_to_start'), root_path, class: 'button')
+= form_tag(finish_session_path, method: :post, class: 'util_mb-medium util_mt-medium') do
+  = submit_tag(t('confirmation.finish'), class: 'button', role: 'button')

--- a/app/views/confirmations/_footer.html.slim
+++ b/app/views/confirmations/_footer.html.slim
@@ -1,8 +1,3 @@
-p.util_mt-large.no-print
-  strong.block.bold-small =t('confirmation.feedback.heading')
-  strong.block.bold-small
-    a href="#{Rails.application.config.feedback_url}" =t('confirmation.feedback.link')
-
 .js-only.no-print
   p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')
 

--- a/config/locales/en_confirmation.yml
+++ b/config/locales/en_confirmation.yml
@@ -85,6 +85,7 @@ en:
           three: If your application for help with fees is successful, you'll hear directly from the tribunal dealing with your case.
     print: Save or print this page
     back_to_start: Back to start
+    finish: Finish application
     feedback:
       heading: Tell us what you think and help improve the service
       link: Give us your feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   resource :session, only: :destroy do
     get :start
+    post :finish
   end
 
   resource :help_request, only: %i[new create], path: 'ask-for-help'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,5 @@ et:
   scotland_email: GLASGOWET@hmcts.gsi.gov.uk
 homepage:
   external_url: <%= ENV['HOMEPAGE_EXTERNAL_URL'] || nil %>
+done_page:
+  external_url: <%= ENV['DONE_PAGE_EXTERNAL_URL'] || nil %>

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ConfirmationsController, type: :controller do
   let(:session) { double }
   let(:online_application) { double(benefits: true) }
   let(:result) { { result: true, message: 'HWF-010101' } }
-  let(:storage) { double(submission_result: result, time_taken: 600, clear: nil) }
+  let(:storage) { double(submission_result: result, time_taken: 600) }
   let(:builder) { double(online_application: online_application) }
 
   before do
@@ -29,10 +29,6 @@ RSpec.describe ConfirmationsController, type: :controller do
     it 'assigns the response object from the session' do
       expect(assigns(:result)).to eql(result)
     end
-
-    it 'does not clear the storage' do
-      expect(storage).not_to have_received(:clear)
-    end
   end
 
   describe 'GET #done' do
@@ -50,10 +46,6 @@ RSpec.describe ConfirmationsController, type: :controller do
 
     it 'assigns the response object from the session' do
       expect(assigns(:result)).to eql(result)
-    end
-
-    it 'clears the storage' do
-      expect(storage).to have_received(:clear)
     end
   end
 
@@ -73,10 +65,6 @@ RSpec.describe ConfirmationsController, type: :controller do
     it 'assigns the response object from the session' do
       expect(assigns(:result)).to eql(result)
     end
-
-    it 'clears the storage' do
-      expect(storage).to have_received(:clear)
-    end
   end
 
   describe 'GET #et' do
@@ -94,10 +82,6 @@ RSpec.describe ConfirmationsController, type: :controller do
 
     it 'assigns the response object from the session' do
       expect(assigns(:result)).to eql(result)
-    end
-
-    it 'clears the storage' do
-      expect(storage).to have_received(:clear)
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
   let(:session) { double }
-  let(:storage) { double(start: nil) }
+  let(:storage) { double(start: nil, clear: nil) }
 
   before do
     allow(controller).to receive(:session).and_return(session)
-    expect(Storage).to receive(:new).with(session, clear: true).and_return(storage)
   end
 
   describe 'GET #start' do
     before do
+      expect(Storage).to receive(:new).with(session, clear: true).and_return(storage)
+
       get :start
     end
 
@@ -23,8 +24,26 @@ RSpec.describe SessionsController, type: :controller do
     end
   end
 
+  describe 'POST #finish' do
+    before do
+      expect(Storage).to receive(:new).with(session).and_return(storage)
+
+      post :finish
+    end
+
+    it 'clears the storage' do
+      expect(storage).to have_received(:clear)
+    end
+
+    it 'redirects to the homepage' do
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
   describe 'DELETE #destroy' do
     before do
+      expect(Storage).to receive(:new).with(session, clear: true).and_return(storage)
+
       delete :destroy
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe 'POST #finish' do
+    let(:external_url) { nil }
+    let(:done_page_settings) { double(external_url: external_url) }
+
     before do
+      allow(Settings).to receive(:done_page).and_return(done_page_settings)
       expect(Storage).to receive(:new).with(session).and_return(storage)
 
       post :finish
@@ -35,9 +39,20 @@ RSpec.describe SessionsController, type: :controller do
       expect(storage).to have_received(:clear)
     end
 
-    it 'redirects to the homepage' do
-      expect(response).to redirect_to(root_path)
+    context 'when the done page external url is set' do
+      let(:external_url) { 'http://som.e.t.h.i.ng' }
+
+      it 'redirects to the external page' do
+        expect(response).to redirect_to(external_url)
+      end
     end
+
+    context 'when no done page external url is set' do
+      it 'redirects to the homepage' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
   end
 
   describe 'DELETE #destroy' do

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -71,5 +71,8 @@ RSpec.feature 'As a user' do
     expect(page).to have_content 'Your application for help with fees is not finished yet'
     click_link_or_button 'Continue'
     expect(page).to have_content 'Send your N1 form with your HWF-123-KLM reference on it to complete the process'
+
+    click_link_or_button 'Finish application'
+    expect(page).to have_content 'Apply for help with court and tribunal fees'
   end
 end


### PR DESCRIPTION
This includes changes on the last confirmation page. When clicking the Finish application button, the user is redirected either back to the home page, or to an external `done page` if set up.