### PR TITLE
fix for hint display

### DIFF
--- a/app/assets/stylesheets/local/inputs.scss
+++ b/app/assets/stylesheets/local/inputs.scss
@@ -34,9 +34,14 @@
 
 .optional {
   label, .hint {
-    display: inline;
+    float: left;
+    margin-right: 5px;
+  }
+  .hint {
+    @include core-19;
   }
   input {
+    clear: left;
     display: block;
   }
 }


### PR DESCRIPTION
Hints were showing with no space on non-local envs due to minified HTML versus pretty HTML. Go figure.

This fixes the display of these so that they are not dependent on HTML whitespace.