### PR TITLE
missing fieldsets on new income pages

### DIFF
--- a/app/views/questions/forms/_income_kind.html.slim
+++ b/app/views/questions/forms/_income_kind.html.slim
@@ -1,32 +1,32 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 = hidden_field_tag 'income_kind[applicant][]', nil
 = hidden_field_tag 'income_kind[partner][]', nil
 
-.grid-row
-  .column-half
-    .form-group.income-sources class=('error' if @form.errors[:applicant].any?)
-      - if @online_application.married?
-        h3.heading-small Your income
-
-      - if @form.errors[:applicant].any?
-        span.error-message#applicant = @form.errors[:applicant].join(' ')
-
-      - @form.class.allowed_kinds.each do |kind|
-        label.block-label for='income_kind_applicant_#{kind}'
-          = f.check_box :applicant, { multiple: true }, kind, nil
-          = t(kind, scope: [@form.i18n_scope, 'kinds'])
-
-  - if @online_application.married?
+fieldset
+  legend.visuallyhidden= t("details#{i18n_status_refund_suffix}", scope: @form.i18n_scope)
+  .grid-row
     .column-half
-      .form-group.income-sources class=('error' if @form.errors[:partner].any?)
-        h3.heading-small Your partner's income
+      .form-group.income-sources class=('error' if @form.errors[:applicant].any?)
+        - if @online_application.married?
+          h3.heading-small Your income
 
-        - if @form.errors[:partner].any?
-          span.error-message#partner = @form.errors[:partner].join(' ')
+        - if @form.errors[:applicant].any?
+          span.error-message#applicant = @form.errors[:applicant].join(' ')
 
         - @form.class.allowed_kinds.each do |kind|
-          label.block-label for='income_kind_partner_#{kind}'
-            = f.check_box :partner, { multiple: true }, kind, nil
+          label.block-label for='income_kind_applicant_#{kind}'
+            = f.check_box :applicant, { multiple: true }, kind, nil
             = t(kind, scope: [@form.i18n_scope, 'kinds'])
+
+    - if @online_application.married?
+      .column-half
+        .form-group.income-sources class=('error' if @form.errors[:partner].any?)
+          h3.heading-small Your partner's income
+
+          - if @form.errors[:partner].any?
+            span.error-message#partner = @form.errors[:partner].join(' ')
+
+          - @form.class.allowed_kinds.each do |kind|
+            label.block-label for='income_kind_partner_#{kind}'
+              = f.check_box :partner, { multiple: true }, kind, nil
+              = t(kind, scope: [@form.i18n_scope, 'kinds'])
 

--- a/app/views/questions/forms/_income_range.html.slim
+++ b/app/views/questions/forms/_income_range.html.slim
@@ -1,22 +1,22 @@
-legend.visuallyhidden = t('text', scope: @form.i18n_scope)
-
 - income_thresholds = Views::IncomeThresholds.new(@online_application)
 - min_threshold = number_to_currency(income_thresholds.min_threshold, precision: 0, unit: '£')
 - max_threshold = number_to_currency(income_thresholds.max_threshold, precision: 0, unit: '£')
 
-.form-group class=('error' if @form.errors.any?)
-  = f.hidden_field :choice, value: nil
-  - if @form.errors.any?
-    span.error-message#choice = @form.errors[:choice].join(' ')
-  label.block-label for='income_range_choice_less'
-    = f.radio_button :choice, :less
-    = t('less', scope: [@form.i18n_scope, 'range'], min_threshold: min_threshold)
+fieldset
+  legend.visuallyhidden = t("details.kinds_list#{i18n_status_refund_suffix}", scope: @form.i18n_scope)
+  .form-group class=('error' if @form.errors.any?)
+    = f.hidden_field :choice, value: nil
+    - if @form.errors.any?
+      span.error-message#choice = @form.errors[:choice].join(' ')
+    label.block-label for='income_range_choice_less'
+      = f.radio_button :choice, :less
+      = t('less', scope: [@form.i18n_scope, 'range'], min_threshold: min_threshold)
 
-  label.block-label for='income_range_choice_between'
-    = f.radio_button :choice, :between
-    = t('between', scope: [@form.i18n_scope, 'range'], min_threshold: min_threshold, max_threshold: max_threshold)
+    label.block-label for='income_range_choice_between'
+      = f.radio_button :choice, :between
+      = t('between', scope: [@form.i18n_scope, 'range'], min_threshold: min_threshold, max_threshold: max_threshold)
 
-  label.block-label for='income_range_choice_more'
-    = f.radio_button :choice, :more
-    = t('more', scope: [@form.i18n_scope, 'range'], max_threshold: max_threshold)
+    label.block-label for='income_range_choice_more'
+      = f.radio_button :choice, :more
+      = t('more', scope: [@form.i18n_scope, 'range'], max_threshold: max_threshold)
 


### PR DESCRIPTION
In creating the new income flow, some old `<legend>` tags got left in and not updated. Also, on IE8, the fact that a `<legend>` is only valid inside a `<fieldset>` meant that the browser ignored the CSS, and displayed the text of the tag rather than keeping it `visuallyhidden`.

`<fieldset>`s have been added and the text of the `<legend>`s has been corrected.

Fixes [this Pivotal bug](https://www.pivotaltracker.com/story/show/126577453).