### PR TITLE
Support income range

### DIFF
--- a/app/models/forms/base_range.rb
+++ b/app/models/forms/base_range.rb
@@ -3,5 +3,20 @@ module Forms
     attribute :choice, Symbol
 
     validates :choice, inclusion: { in: %i[less between more] }
+
+    private
+
+    def export_params
+      case choice
+      when :less
+        { min_threshold_name => false }
+      when :between
+        { min_threshold_name => true, max_threshold_name => false }
+      when :more
+        { min_threshold_name => true, max_threshold_name => true }
+      else
+        {}
+      end
+    end
   end
 end

--- a/app/models/forms/base_range.rb
+++ b/app/models/forms/base_range.rb
@@ -1,0 +1,7 @@
+module Forms
+  class BaseRange < Base
+    attribute :choice, Symbol
+
+    validates :choice, inclusion: { in: %i[less between more] }
+  end
+end

--- a/app/models/forms/income_range.rb
+++ b/app/models/forms/income_range.rb
@@ -2,17 +2,12 @@ module Forms
   class IncomeRange < BaseRange
     private
 
-    def export_params
-      case choice
-      when :less
-        { income_min_threshold_exceeded: false }
-      when :between
-        { income_min_threshold_exceeded: true, income_max_threshold_exceeded: false }
-      when :more
-        { income_min_threshold_exceeded: true, income_max_threshold_exceeded: true }
-      else
-        {}
-      end
+    def min_threshold_name
+      :income_min_threshold_exceeded
+    end
+
+    def max_threshold_name
+      :income_max_threshold_exceeded
     end
   end
 end

--- a/app/models/forms/income_range.rb
+++ b/app/models/forms/income_range.rb
@@ -1,9 +1,5 @@
 module Forms
-  class IncomeRange < Base
-    attribute :choice, Symbol
-
-    validates :choice, inclusion: { in: %i[less between more] }
-
+  class IncomeRange < BaseRange
     private
 
     def export_params

--- a/app/models/forms/income_range.rb
+++ b/app/models/forms/income_range.rb
@@ -7,7 +7,16 @@ module Forms
     private
 
     def export_params
-      {}
+      case choice
+      when :less
+        { income_min_threshold_exceeded: false }
+      when :between
+        { income_min_threshold_exceeded: true, income_max_threshold_exceeded: false }
+      when :more
+        { income_min_threshold_exceeded: true, income_max_threshold_exceeded: true }
+      else
+        {}
+      end
     end
   end
 end

--- a/app/models/forms/savings_and_investment.rb
+++ b/app/models/forms/savings_and_investment.rb
@@ -2,17 +2,12 @@ module Forms
   class SavingsAndInvestment < BaseRange
     private
 
-    def export_params
-      case choice
-      when :less
-        { min_threshold_exceeded: false }
-      when :between
-        { min_threshold_exceeded: true, max_threshold_exceeded: false }
-      when :more
-        { min_threshold_exceeded: true, max_threshold_exceeded: true }
-      else
-        {}
-      end
+    def min_threshold_name
+      :min_threshold_exceeded
+    end
+
+    def max_threshold_name
+      :max_threshold_exceeded
     end
   end
 end

--- a/app/models/forms/savings_and_investment.rb
+++ b/app/models/forms/savings_and_investment.rb
@@ -1,9 +1,5 @@
 module Forms
-  class SavingsAndInvestment < Base
-    attribute :choice, Symbol
-
-    validates :choice, inclusion: { in: %i[less between more] }
-
+  class SavingsAndInvestment < BaseRange
     private
 
     def export_params

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -8,6 +8,8 @@ class OnlineApplication
   attribute :amount, Integer
   attribute :benefits, Boolean
   attribute :children, Integer
+  attribute :income_min_threshold_exceeded, Boolean
+  attribute :income_max_threshold_exceeded, Boolean
   attribute :income, Integer
   attribute :refund, Boolean
   attribute :date_fee_paid, Date

--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -22,7 +22,17 @@ module Views
       elsif online_application.over_61?
         I18n.t('between', scope: scope)
       else
-        number_to_currency(online_application.amount, precision: 0, unit: '£')
+        format_currency(online_application.amount)
+      end
+    end
+
+    def income_text
+      if online_application.income_min_threshold_exceeded? == false
+        format_below_threshold
+      elsif online_application.income_max_threshold_exceeded?
+        format_above_threshold
+      elsif online_application.income
+        format_currency(online_application.income)
       end
     end
 
@@ -48,6 +58,24 @@ module Views
 
     def payment_date
       ", on #{date_fee_paid}" if refund
+    end
+
+    def format_currency(amount)
+      number_to_currency(amount, precision: 0, unit: '£')
+    end
+
+    def income_thresholds
+      Views::IncomeThresholds.new(online_application)
+    end
+
+    def format_above_threshold
+      scope = 'questions.income_range.range'
+      I18n.t('more', scope: scope, max_threshold: format_currency(income_thresholds.max_threshold))
+    end
+
+    def format_below_threshold
+      scope = 'questions.income_range.range'
+      I18n.t('less', scope: scope, min_threshold: format_currency(income_thresholds.min_threshold))
     end
   end
 end

--- a/app/services/clear_downstream_questions.rb
+++ b/app/services/clear_downstream_questions.rb
@@ -9,6 +9,8 @@ class ClearDownstreamQuestions
        income_kind_change?(new_online_application, old_online_application)
       @storage.clear_form(:income_range)
       @storage.clear_form(:income_amount)
+    elsif income_range_change?(new_online_application, old_online_application)
+      @storage.clear_form(:income_amount)
     end
   end
 
@@ -16,6 +18,14 @@ class ClearDownstreamQuestions
     @question == :income_kind &&
       old_online_application.income != 0 &&
       new_online_application.income == 0
+  end
+
+  def income_range_change?(new_online_application, old_online_application)
+    @question == :income_range &&
+      old_online_application.income_min_threshold_exceeded !=
+        new_online_application.income_min_threshold_exceeded ||
+      old_online_application.income_max_threshold_exceeded !=
+        new_online_application.income_max_threshold_exceeded
   end
 
   def dependent_change?(new_online_application, old_online_application)

--- a/app/services/navigation.rb
+++ b/app/services/navigation.rb
@@ -17,7 +17,7 @@ class Navigation
   private
 
   def next_question_id
-    if skip_income? || skip_further_income?
+    if skip_income? || skip_income_range? || skip_income_amount?
       :probate
     elsif skip_savings_and_investment_extra?
       :benefit
@@ -31,8 +31,14 @@ class Navigation
     @current_question == :benefit && @online_application.benefits?
   end
 
-  def skip_further_income?
-    @current_question == :income_kind && @online_application.income == 0
+  def skip_income_range?
+    (@current_question == :income_kind && @online_application.income == 0)
+  end
+
+  def skip_income_amount?
+    @current_question == :income_range &&
+      (!@online_application.income_min_threshold_exceeded ||
+        @online_application.income_max_threshold_exceeded)
   end
 
   def skip_savings_and_investment_extra?

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -52,10 +52,10 @@ table.summary
           span.visuallyhidden
             | &nbsp;
             =t('children', scope: 'summary.labels').downcase
-    - if @summary.income
+    - if @summary.income_text
       tr
         th scope="row" =t('income', scope: 'summary.labels')
-        td =number_to_currency(@summary.income, precision: 2, unit: '£')
+        td =@summary.income_text
         td.right= link_to question_path(:income_kind) do
           | Change
           span.visuallyhidden

--- a/spec/factories/online_applications.rb
+++ b/spec/factories/online_applications.rb
@@ -49,7 +49,7 @@ FactoryGirl.define do
     end
 
     trait :income_between_thresholds do
-      income nil
+      income 1500
       income_min_threshold_exceeded true
       income_max_threshold_exceeded false
     end

--- a/spec/factories/online_applications.rb
+++ b/spec/factories/online_applications.rb
@@ -47,5 +47,22 @@ FactoryGirl.define do
     trait :no_income do
       income 0
     end
+
+    trait :income_between_thresholds do
+      income nil
+      income_min_threshold_exceeded true
+      income_max_threshold_exceeded false
+    end
+
+    trait :income_below_thresholds do
+      income nil
+      income_min_threshold_exceeded false
+    end
+
+    trait :income_above_thresholds do
+      income nil
+      income_min_threshold_exceeded true
+      income_max_threshold_exceeded true
+    end
   end
 end

--- a/spec/factories/online_applications.rb
+++ b/spec/factories/online_applications.rb
@@ -44,6 +44,12 @@ FactoryGirl.define do
       max_threshold_exceeded false
     end
 
+    trait :income_not_set do
+      income nil
+      income_min_threshold_exceeded nil
+      income_max_threshold_exceeded nil
+    end
+
     trait :no_income do
       income 0
     end

--- a/spec/features/apply_for_help_with_fees_spec.rb
+++ b/spec/features/apply_for_help_with_fees_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'As a user' do
     check 'income_kind_applicant_5'
     click_button 'Continue'
     expect(page).to have_content 'How much income do you receive each month?'
-    choose 'income_range_choice_less'
+    choose 'income_range_choice_between'
     click_button 'Continue'
     expect(page).to have_content 'What’s your total monthly income?'
     fill_in 'income_amount_amount', with: '100'

--- a/spec/features/pages/income_question_spec.rb
+++ b/spec/features/pages/income_question_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'As a user' do
 
     context 'completing the form correctly' do
       before do
-        choose :income_range_choice_less
+        choose :income_range_choice_between
         click_button 'Continue'
       end
 

--- a/spec/models/forms/base_range_spec.rb
+++ b/spec/models/forms/base_range_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+module Forms
+  RSpec.describe BaseRange, type: :model do
+    subject(:form) { described_class.new(choice: choice) }
+
+    describe 'validations' do
+      describe 'choice' do
+        context 'when "less"' do
+          let(:choice) { 'less' }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when "between"' do
+          let(:choice) { 'between' }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when "more"' do
+          let(:choice) { 'more' }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when neither "less, between or more"' do
+          let(:choice) { 'whatever' }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context 'when empty' do
+          let(:choice) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+
+  end
+end

--- a/spec/models/forms/income_range_spec.rb
+++ b/spec/models/forms/income_range_spec.rb
@@ -41,8 +41,36 @@ RSpec.describe Forms::IncomeRange, type: :model do
     let(:choice) { 'more' }
     subject { form.export }
 
-    it 'returns an empty hash' do
-      is_expected.to eql({})
+    context 'when "less"' do
+      let(:choice) { 'less' }
+
+      it 'returns a hash with income_min_threshold_exceeded set to false' do
+        is_expected.to eql(income_min_threshold_exceeded: false)
+      end
+    end
+
+    context 'when "between"' do
+      let(:choice) { 'between' }
+
+      it 'returns hash with income_min_threshold_exceeded parameter true and income_max_threshold_exceeded parameter false' do
+        is_expected.to eql(income_min_threshold_exceeded: true, income_max_threshold_exceeded: false)
+      end
+    end
+
+    context 'when "more"' do
+      let(:choice) { 'more' }
+
+      it 'returns hash with income_min_threshold_exceeded parameter true and income_max_threshold_exceeded parameter true' do
+        is_expected.to eql(income_min_threshold_exceeded: true, income_max_threshold_exceeded: true)
+      end
+    end
+
+    context 'when choice is not set' do
+      let(:choice) { nil }
+
+      it 'returns an empty hash' do
+        is_expected.to eql({})
+      end
     end
   end
 end

--- a/spec/models/forms/income_range_spec.rb
+++ b/spec/models/forms/income_range_spec.rb
@@ -3,40 +3,6 @@ require 'rails_helper'
 RSpec.describe Forms::IncomeRange, type: :model do
   subject(:form) { described_class.new(choice: choice) }
 
-  describe 'validations' do
-    describe 'choice' do
-      context 'when "less"' do
-        let(:choice) { 'less' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when "between"' do
-        let(:choice) { 'between' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when "more"' do
-        let(:choice) { 'more' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when neither "less, between or more"' do
-        let(:choice) { 'whatever' }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context 'when empty' do
-        let(:choice) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-    end
-  end
-
   describe '#export' do
     let(:choice) { 'more' }
     subject { form.export }

--- a/spec/models/forms/savings_and_investment_spec.rb
+++ b/spec/models/forms/savings_and_investment_spec.rb
@@ -3,40 +3,6 @@ require 'rails_helper'
 RSpec.describe Forms::SavingsAndInvestment, type: :model do
   subject(:form) { described_class.new(choice: choice) }
 
-  describe 'validations' do
-    describe 'choice' do
-      context 'when "less"' do
-        let(:choice) { 'less' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when "between"' do
-        let(:choice) { 'between' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when "more"' do
-        let(:choice) { 'more' }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when neither "less, between or more"' do
-        let(:choice) { 'whatever' }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context 'when empty' do
-        let(:choice) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-    end
-  end
-
   describe '#export' do
     subject { form.export }
 

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -67,6 +67,41 @@ RSpec.describe Views::Summary do
     end
   end
 
+  describe '#income_text' do
+    let(:threshold_attributes) { { married: true, children: 3 } }
+    subject { summary.income_text }
+
+    context 'when the income is between the thresholds' do
+      let(:online_application) { build :online_application, :income_between_thresholds, income: 1600 }
+
+      it 'returns the exact income amount formatted as a currency' do
+        is_expected.to eql('£1,600')
+      end
+    end
+
+    context 'when the income is below the thresholds' do
+      let(:online_application) { build :online_application, :income_below_thresholds, threshold_attributes }
+
+      it 'returns copy saying the applicant earns less than the calculated threshold' do
+        is_expected.to eql('Less than £1,980')
+      end
+    end
+
+    context 'when the income is above the thresholds' do
+      let(:online_application) { build :online_application, :income_above_thresholds, threshold_attributes }
+
+      it 'returns copy saying the applicant earns more than the calculated threshold' do
+        is_expected.to eql('More than £5,980')
+      end
+    end
+
+    context 'when income is not set' do
+      let(:online_application) { build :online_application, :income_not_set, threshold_attributes }
+
+      it { is_expected.to be nil }
+    end
+  end
+
   describe '#refund_text' do
     subject { summary.refund_text }
 

--- a/spec/services/clear_downstream_questions_spec.rb
+++ b/spec/services/clear_downstream_questions_spec.rb
@@ -53,5 +53,18 @@ RSpec.describe ClearDownstreamQuestions do
         end
       end
     end
+
+    context 'when the question is "income_range"' do
+      let(:question) { :income_range }
+      let(:old_online_application) { build :online_application, :income_between_thresholds }
+
+      context 'when the range has changed' do
+        let(:new_online_application) { build :online_application, :income_below_thresholds }
+
+        it 'clears income_amount questions' do
+          expect(storage).to have_received(:clear_form).with(:income_amount)
+        end
+      end
+    end
   end
 end

--- a/spec/services/navigation_spec.rb
+++ b/spec/services/navigation_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Navigation do
       marital_status: :savings_and_investment,
       savings_and_investment_extra: :benefit,
       dependent: :income_kind,
-      income_kind: :income_range,
-      income_range: :income_amount,
       income_amount: :probate,
       probate: :claim,
       claim: :national_insurance,
@@ -98,5 +96,34 @@ RSpec.describe Navigation do
         end
       end
     end
+
+    context 'for income_range question' do
+      let(:current_question) { :income_range }
+
+      context 'when the application is between thresholds' do
+        let(:online_application) { build :online_application, :income_between_thresholds }
+
+        it 'routes to the income_amount question' do
+          is_expected.to eql(question_path(:income_amount))
+        end
+      end
+
+      context 'when the application is below thresholds' do
+        let(:online_application) { build :online_application, :income_below_thresholds }
+
+        it 'routes to the probate question' do
+          is_expected.to eql(question_path(:probate))
+        end
+      end
+
+      context 'when the application is above thresholds' do
+        let(:online_application) { build :online_application, :income_above_thresholds }
+
+        it 'routes to the probate question' do
+          is_expected.to eql(question_path(:probate))
+        end
+      end
+    end
+
   end
 end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -181,7 +181,7 @@ module FeatureSteps
   end
 
   def fill_income_range
-    choose 'income_range_choice_less'
+    choose 'income_range_choice_between'
     click_button 'Continue'
   end
 


### PR DESCRIPTION
This is an improvement on the income flow, which skips the 3rd page when the user earns either less or more than the thresholds. If they earn between the thresholds, the 3rd page is displayed. 

For this to work, the https://github.com/ministryofjustice/fr-staffapp/pull/697 has to be merged first..