### PR TITLE
Extend the healthchecks

### DIFF
--- a/app/services/health_status/health_check.rb
+++ b/app/services/health_status/health_check.rb
@@ -2,15 +2,20 @@ module HealthStatus
   class HealthCheck
     def initialize
       check_submission_api!
+      downstream_api_ok?
     end
 
-    def as_json(_options = {})
+    def as_json(_options = {}) # rubocop:disable Metrics/MethodLength
       {
         submission_api: {
           description: 'Submission API',
           ok: @submission_api_available
         },
-        ok: @submission_api_available
+        downstream_api_ok: {
+          description: 'Downstream API',
+          ok: @downstream_api_ok
+        },
+        ok: @submission_api_available && @downstream_api_ok
       }
     end
 
@@ -23,6 +28,11 @@ module HealthStatus
     def check_submission_api!
       service = SubmitApplication.new(Settings.submission.url, Settings.submission.token)
       @submission_api_available = service.available?
+    end
+
+    def downstream_api_ok?
+      json = JSON.parse(RestClient.get("#{Settings.submission.url}/healthcheck.json"))
+      @downstream_api_ok = json['ok']
     end
   end
 end

--- a/app/services/health_status/health_check.rb
+++ b/app/services/health_status/health_check.rb
@@ -31,14 +31,14 @@ module HealthStatus
     end
 
     def downstream_api_ok?
-      json = JSON.parse(staff_app_health_check_result)
-      @downstream_api_ok = json['ok']
+      @downstream_api_ok = staff_app_health_check_result
     end
 
     def staff_app_health_check_result
-      RestClient.get("#{Settings.submission.url}/healthcheck.json")
-    rescue => e
-      e.response
+      json = JSON.parse(RestClient.get("#{Settings.submission.url}/healthcheck.json"))
+      json['ok']
+    rescue
+      false
     end
   end
 end

--- a/app/services/health_status/health_check.rb
+++ b/app/services/health_status/health_check.rb
@@ -31,8 +31,14 @@ module HealthStatus
     end
 
     def downstream_api_ok?
-      json = JSON.parse(RestClient.get("#{Settings.submission.url}/healthcheck.json"))
+      json = JSON.parse(staff_app_health_check_result)
       @downstream_api_ok = json['ok']
+    end
+
+    def staff_app_health_check_result
+      RestClient.get("#{Settings.submission.url}/healthcheck.json")
+    rescue => e
+      e.response
     end
   end
 end

--- a/spec/services/health_status/health_check_spec.rb
+++ b/spec/services/health_status/health_check_spec.rb
@@ -4,41 +4,94 @@ RSpec.describe HealthStatus::HealthCheck, type: :service do
   subject(:service) { described_class.new }
 
   let(:submit_application) { double(available?: submit_application_available?) }
+  let(:downstream_api) { double(available?: downstream_api_ok?) }
+  let(:downstream_api_ok?) { true }
+  let(:json_returned) { "{\"database\":{\"description\":\"Postgres database\",\"ok\":true},\"ok\":#{downstream_api_ok?}}" }
 
   before do
+    stub_request(:get, "http://submit.to.this/healthcheck.json").
+      to_return(status: 200, body: json_returned, headers: {})
     allow(SubmitApplication).to receive(:new).and_return(submit_application)
   end
 
   describe '#as_json' do
     subject { service.as_json }
 
-    context 'when the submission api is available' do
-      let(:submit_application_available?) { true }
+    context 'when there are no issues with the downstream health check' do
+      context 'when the submission api is available' do
+        let(:submit_application_available?) { true }
 
-      it 'returns hash with all services ok' do
-        is_expected.to eql(
-          submission_api: {
-            description: 'Submission API',
+        it 'returns hash with all services ok' do
+          is_expected.to eql(
+            submission_api: {
+              description: 'Submission API',
+              ok: true
+            },
+            downstream_api_ok: {
+              description: 'Downstream API',
+              ok: true
+            },
             ok: true
-          },
-          ok: true
-        )
+          )
+        end
+      end
+
+      context 'when the submission api is not available' do
+        let(:submit_application_available?) { false }
+
+        it 'returns hash with services unavailable' do
+          is_expected.to eql(
+            submission_api: {
+              description: 'Submission API',
+              ok: false
+            },
+            downstream_api_ok: {
+              description: 'Downstream API',
+              ok: true
+            },
+            ok: false
+          )
+        end
       end
     end
+    context 'when there are issues with the downstream health check' do
+      let(:downstream_api_ok?) { false }
 
-    context 'when the submission api is not available' do
-      let(:submit_application_available?) { false }
+      context 'when the submission api is available' do
+        let(:submit_application_available?) { true }
 
-      it 'returns hash with services unavailable' do
-        is_expected.to eql(
-          submission_api: {
-            description: 'Submission API',
+        it 'returns hash with all services ok' do
+          is_expected.to eql(
+            submission_api: {
+              description: 'Submission API',
+              ok: true
+            },
+            downstream_api_ok: {
+              description: 'Downstream API',
+              ok: false
+            },
             ok: false
-          },
-          ok: false
-        )
+          )
+        end
       end
 
+      context 'when the submission api is not available' do
+        let(:submit_application_available?) { false }
+
+        it 'returns hash with services unavailable' do
+          is_expected.to eql(
+            submission_api: {
+              description: 'Submission API',
+              ok: false
+            },
+            downstream_api_ok: {
+              description: 'Downstream API',
+              ok: false
+            },
+            ok: false
+          )
+        end
+      end
     end
   end
 

--- a/spec/services/health_status/health_check_spec.rb
+++ b/spec/services/health_status/health_check_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HealthStatus::HealthCheck, type: :service do
 
   before do
     stub_request(:get, "http://submit.to.this/healthcheck.json").
-      to_return(status: 200, body: json_returned, headers: {})
+      to_return(status: downstream_api_ok? ? 200 : 500, body: json_returned, headers: {})
     allow(SubmitApplication).to receive(:new).and_return(submit_application)
   end
 


### PR DESCRIPTION
Added downstream_api to public health check, this looks at the staff app and returns the overall staff health check result and bubble the results up to pingdom.

Leaving healthy? as a standalone method still allows the public to submit applications, while allowing us to alert to failures of both the staff and public apps via pingdom.