### PR TITLE
split step info out of H1 tag

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -8,6 +8,11 @@ li,
   margin-bottom: 0.625em;
 }
 
+.step-info {
+  @include core-24;
+  color: $grey-1;
+}
+
 .hint {
   color: $grey-1;
 }

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -2,10 +2,9 @@
   = t('title', scope: @form.i18n_scope)
   = ' - '
 
-h1.heading-large
-  span.heading-secondary= t('breadcrumb', scope: @form.i18n_scope)
-  span.visuallyhidden
-    | :&nbsp;
+p.step-info.util_mt-large.util_mb-0
+  = t('breadcrumb', scope: @form.i18n_scope)
+h1.heading-large.util_mt-0
   = t(@title_view.i18n_title, scope: @form.i18n_scope)
 
 = render('shared/error_block', form: @form) if @form.errors.any?


### PR DESCRIPTION
Splits the step info e.g. "Step 2 of 20" out of the page's main `<h1>` tag since having it inside the `<h1>` was causing at least one screen reader to report multiple level 1 headings on the page.