### PR TITLE
Validate benefit income

### DIFF
--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -3,6 +3,10 @@ module Views
     # TODO: Use a different way of including helpers
     include ActionView::Helpers::NumberHelper
 
+    def income_validation_fails?
+      benefits.eql?(false) && income.nil?
+    end
+
     def refund_text
       message = I18n.t("fee_paid_#{refund}", scope: 'summary')
       "#{message}#{payment_date}"

--- a/app/views/summaries/show.html.slim
+++ b/app/views/summaries/show.html.slim
@@ -8,6 +8,9 @@ h1.heading-large
     | :&nbsp;
   =t('title', scope: 'summary.labels')
 
+.text
+  p =t('summary.details')
+
 table.summary
   caption.visuallyhidden Please check the details of your application for help with fees
   tbody
@@ -43,24 +46,46 @@ table.summary
         span.visuallyhidden
           | &nbsp;
           =t('benefits', scope: 'summary.labels').downcase
-    - if @summary.children_text
+    - if @summary.income_validation_fails?
       tr
-        th scope="row" =t('children', scope: 'summary.labels')
-        td =@summary.children_text
+        th scope="row"
+          span.error-message = t('children', scope: 'summary.labels')
+        td.error
+          span.error-message =t('summary.missing_answer.dependents')
         td.right= link_to question_path(:dependent) do
           | Change
           span.visuallyhidden
             | &nbsp;
-            =t('children', scope: 'summary.labels').downcase
-    - if @summary.income_text
+            = t('children', scope: 'summary.labels').downcase
       tr
-        th scope="row" =t('income', scope: 'summary.labels')
-        td =@summary.income_text
+        th scope="row"
+          span.error-message = t('income', scope: 'summary.labels')
+        td.error
+          span.error-message =t('summary.missing_answer.income')
         td.right= link_to question_path(:income_kind) do
           | Change
           span.visuallyhidden
             | &nbsp;
-            =t('income', scope: 'summary.labels').downcase
+            = t('income', scope: 'summary.labels').downcase
+    -else
+      - if @summary.children_text
+        tr
+          th scope="row" =t('children', scope: 'summary.labels')
+          td =@summary.children_text
+          td.right= link_to question_path(:dependent) do
+            | Change
+            span.visuallyhidden
+              | &nbsp;
+              =t('children', scope: 'summary.labels').downcase
+      - if @summary.income_text
+        tr
+          th scope="row" =t('income', scope: 'summary.labels')
+          td =@summary.income_text
+          td.right= link_to question_path(:income_kind) do
+            | Change
+            span.visuallyhidden
+              | &nbsp;
+              =t('income', scope: 'summary.labels').downcase
     tr
       th scope="row" =t('fee', scope: 'summary.labels')
       td =@summary.refund_text
@@ -154,13 +179,16 @@ table.summary
             | &nbsp;
             =t('contact', scope: 'summary.labels').downcase
 
-.text
-  h2.heading-medium =t('heading', scope: 'summary.truth')
-  p =t('statement', scope: 'summary.truth')
-
-= form_tag(submission_path, method: :post, class: 'util_mb-medium util_mt-medium') do
-  = submit_tag(t('button', scope: 'summary.truth'), class: 'button', role: 'button')
-
+- if @summary.income_validation_fails?
+  .form-group.error.util_mt-small
+    span.util_mt-small.error-message =t('summary.invalid_footer')
+    p = link_to 'Continue', question_path(:dependent), class: 'button'
+- else
+  .text
+    h2.heading-medium = t('heading', scope: 'summary.truth')
+    p = t('statement', scope: 'summary.truth')
+    = form_tag(submission_path, method: :post, class: 'util_mb-medium util_mt-medium') do
+      = submit_tag(t('button', scope: 'summary.truth'), class: 'button', role: 'button')
 .text
   p
     strong.block.bold-small =t('session.note.heading')

--- a/config/locales/en_post_welsh.yml
+++ b/config/locales/en_post_welsh.yml
@@ -1,0 +1,7 @@
+en:
+  summary:
+    missing_answer:
+      dependents: 'Please give details of children or dependents'
+      income: 'Please answer questions about your income'
+    details: 'Please check your details are correct. If you make changes, you may have to answer new questions and confirm information you’ve already entered.'
+    invalid_footer: 'You’ve made changes. Please answer the highlighted questions to complete your application.'

--- a/spec/features/pages/summary_spec.rb
+++ b/spec/features/pages/summary_spec.rb
@@ -9,6 +9,8 @@ RSpec.feature 'As a user' do
         choose 'dependent_children_true'
         fill_in :dependent_children_number, with: '10'
         click_button 'Continue'
+        check :income_kind_applicant_13
+        click_button 'Continue'
         page.visit '/summary'
       end
 
@@ -21,6 +23,8 @@ RSpec.feature 'As a user' do
       before do
         given_user_answers_questions_up_to(:dependent)
         choose 'dependent_children_false'
+        click_button 'Continue'
+        check :income_kind_applicant_13
         click_button 'Continue'
         page.visit '/summary'
       end

--- a/spec/features/user_switches_from_benefits_but_avoids_income_spec.rb
+++ b/spec/features/user_switches_from_benefits_but_avoids_income_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'User completes their application' do
+  scenario 'up to the summary page' do
+    given_user_provides_all_data_for_benefit
+    find(:xpath, "//a[@href='#{question_path(:benefit)}']").click
+    choose :benefit_on_benefits_false
+    click_button 'Continue'
+    # simulate user returning to summary via the back button (twice)
+    visit summary_path
+    expect(page).to have_content 'Check details'
+    expect(page).to have_content 'Not receiving eligible benefits'
+    expect(page).to have_content 'IncomePlease answer questions about your income'
+    expect(page).to have_content 'You’ve made changes. Please answer the highlighted questions to complete your application.'
+  end
+end

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -11,6 +11,44 @@ RSpec.describe Views::Summary do
     end
   end
 
+  describe 'income_validation_fails?' do
+    subject { summary.income_validation_fails? }
+
+    let(:online_application) { build :online_application, income: income, benefits: benefits }
+
+    context 'when benefits are true' do
+      let(:benefits) { true }
+
+      context 'and income is nil' do
+        let(:income) { nil }
+
+        it { is_expected.to be false }
+      end
+
+      context 'and income is set' do
+        let(:income) { 0 }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when benefits are false' do
+      let(:benefits) { false }
+
+      context 'and income is nil' do
+        let(:income) { nil }
+
+        it { is_expected.to be true }
+      end
+
+      context 'and income is set' do
+        let(:income) { 0 }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe '#form_name' do
     let(:online_application) { build :online_application, form_name: form_name }
 

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -36,6 +36,24 @@ module FeatureSteps
     fill_contact
   end
 
+  def given_user_provides_all_data_for_benefit
+    visit '/'
+    click_link_or_button 'Apply now'
+    fill_form_name
+    fill_fee
+    fill_marital_status
+    fill_savings_and_investment
+    fill_savings_and_investment_extra
+    fill_benefit(true)
+    fill_probate
+    fill_claim
+    fill_national_insurance
+    fill_dob
+    fill_personal_detail
+    fill_applicant_address
+    fill_contact
+  end
+
   def given_user_starts_an_application
     given_user_answers_questions_up_to(:savings_and_investment)
   end
@@ -195,8 +213,8 @@ module FeatureSteps
     click_button 'Continue'
   end
 
-  def fill_benefit
-    choose 'benefit_on_benefits_false'
+  def fill_benefit(benefit = false)
+    choose "benefit_on_benefits_#{benefit}"
     click_button 'Continue'
   end
 


### PR DESCRIPTION
## Issue:
We are receiving data in the staff app in an invalid state

## Supposition:
The only way we can replicate the state is to complete a benefits application and, via the change and back buttons, set benefits to false and return to the summary page.

## Fix: 
Add validation to the summary object and alert users to issues that need rectifying.

## Notes:
* There are plans to implement dynamic routing of questions in the future, but that is outside the current support scope.
* the weird name of the yaml file is to prevent conflicts with the welsh-version branch being merged