### PR TITLE
Validate income fix

### DIFF
--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -4,7 +4,7 @@ module Views
     include ActionView::Helpers::NumberHelper
 
     def income_validation_fails?
-      benefits.eql?(false) && income.nil?
+      benefits.eql?(false) && income.nil? && income_text.nil?
     end
 
     def refund_text

--- a/spec/features/user_switches_from_benefits_but_avoids_income_spec.rb
+++ b/spec/features/user_switches_from_benefits_but_avoids_income_spec.rb
@@ -1,16 +1,18 @@
 require 'rails_helper'
 
-RSpec.feature 'User completes their application' do
-  scenario 'up to the summary page' do
+RSpec.feature 'User completes their' do
+  scenario 'benefit application up to the summary page' do
     given_user_provides_all_data_for_benefit
     find(:xpath, "//a[@href='#{question_path(:benefit)}']").click
     choose :benefit_on_benefits_false
     click_button 'Continue'
     # simulate user returning to summary via the back button (twice)
     visit summary_path
-    expect(page).to have_content 'Check details'
-    expect(page).to have_content 'Not receiving eligible benefits'
-    expect(page).to have_content 'IncomePlease answer questions about your income'
-    expect(page).to have_content 'You’ve made changes. Please answer the highlighted questions to complete your application.'
+    then_they_cannot_procced
+  end
+
+  scenario 'below threshold income application up to the summary page' do
+    given_user_provides_all_data_for_below_threshold_income
+    then_they_can_proceed
   end
 end

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -33,10 +33,23 @@ RSpec.describe Views::Summary do
     end
 
     context 'when benefits are false' do
+      let(:threshold_attributes) { { married: true, children: 3, benefits: benefits } }
       let(:benefits) { false }
 
-      context 'and income is nil' do
-        let(:income) { nil }
+      context 'when the income is below the thresholds' do
+        let(:online_application) { build :online_application, :income_below_thresholds, threshold_attributes }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the income is above the thresholds' do
+        let(:online_application) { build :online_application, :income_above_thresholds, threshold_attributes }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when income is not set' do
+        let(:online_application) { build :online_application, :income_not_set, threshold_attributes }
 
         it { is_expected.to be true }
       end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -36,6 +36,27 @@ module FeatureSteps
     fill_contact
   end
 
+  def given_user_provides_all_data_for_below_threshold_income
+    visit '/'
+    click_link_or_button 'Apply now'
+    fill_form_name
+    fill_fee(true)
+    fill_marital_status
+    fill_savings_and_investment
+    fill_savings_and_investment_extra
+    fill_benefit
+    fill_dependent
+    fill_income_kind
+    fill_income_range(below: true)
+    fill_probate
+    fill_claim
+    fill_national_insurance
+    fill_dob
+    fill_personal_detail
+    fill_applicant_address
+    fill_contact
+  end
+
   def given_user_provides_all_data_for_benefit
     visit '/'
     click_link_or_button 'Apply now'
@@ -129,6 +150,20 @@ module FeatureSteps
     expect(page).to have_text 'You must email or post this help with fees reference number HWF-ABC123 along with your employment tribunal claim number to the employment tribunal.'
   end
 
+  def then_they_cannot_procced
+    expect(page).to have_content 'Check details'
+    expect(page).to have_content 'Not receiving eligible benefits'
+    expect(page).to have_content 'IncomePlease answer questions about your income'
+    expect(page).to have_content 'You’ve made changes. Please answer the highlighted questions to complete your application.'
+  end
+
+  def then_they_can_proceed
+    expect(page).to have_content 'Check details'
+    expect(page).to have_content 'Not receiving eligible benefits'
+    expect(page).to have_content 'IncomeLess than £1,085'
+    expect(page).to have_content 'Submit application and continue'
+  end
+
   def fill_contact
     fill_in 'contact_email', with: 'foo@bar.com'
     click_button 'Continue'
@@ -198,8 +233,12 @@ module FeatureSteps
     click_button 'Continue'
   end
 
-  def fill_income_range
-    choose 'income_range_choice_between'
+  def fill_income_range(below = false)
+    if below
+      choose :income_range_choice_less
+    else
+      choose :income_range_choice_between
+    end
     click_button 'Continue'
   end
 


### PR DESCRIPTION
The previous PR fixed the main issue but missed a subset of applications.

This adds tests for the extra validation scenario and then implements the fix.