### PR TITLE
Remove probate from ET flow

### DIFF
--- a/app/services/navigation.rb
+++ b/app/services/navigation.rb
@@ -18,7 +18,7 @@ class Navigation
 
   def next_question_id
     if skip_income? || skip_income_range? || skip_income_amount?
-      :probate
+      probate_or_claim
     elsif skip_savings_and_investment_extra?
       :benefit
     else
@@ -44,5 +44,9 @@ class Navigation
   def skip_savings_and_investment_extra?
     @current_question == :savings_and_investment &&
       !@online_application.savings_and_investment_extra_required?
+  end
+
+  def probate_or_claim
+    @online_application.et? ? :claim : :probate
   end
 end

--- a/app/services/question_form_factory.rb
+++ b/app/services/question_form_factory.rb
@@ -36,6 +36,8 @@ class QuestionFormFactory
   def self.form_class_name(id, online_application)
     if id == :claim
       online_application.et? ? 'Claim::Et' : 'Claim::Default'
+    elsif id == :probate && online_application.et?
+      'Claim::Et'
     else
       id.to_s.classify
     end

--- a/spec/features/pages/probate_question_spec.rb
+++ b/spec/features/pages/probate_question_spec.rb
@@ -87,4 +87,24 @@ RSpec.feature 'As a user' do
       end
     end
   end
+
+  context 'when completing an ET application' do
+    before do
+      when_they_go_back_to_homepage_and_start_again
+      fill_et_form_name
+      fill_fee
+      fill_marital_status
+      fill_savings_and_investment
+      fill_savings_and_investment_extra
+      fill_benefit
+      fill_dependent
+      fill_income_kind
+      fill_income_range
+      fill_income_amount
+    end
+
+    scenario 'the probate page is not rendered' do
+      expect(page).to have_content 'Enter your employment tribunal claim number'
+    end
+  end
 end

--- a/spec/services/navigation_spec.rb
+++ b/spec/services/navigation_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe Navigation do
     end
 
     context 'for benefit question' do
-      let(:online_application) { build :online_application, benefits: benefits }
+      let(:online_application) { build :online_application, benefits: benefits, form_name: form_name }
       let(:current_question) { :benefit }
+      let(:form_name) { nil }
 
       context 'when the application is benefit one' do
         let(:benefits) { true }
@@ -41,7 +42,15 @@ RSpec.describe Navigation do
         it 'routes to the probate question (skips dependent and income)' do
           is_expected.to eql(question_path(:probate))
         end
+
+        context 'when the application is for ET' do
+          let(:form_name) { 'ET1' }
+          it 'routes to the claim question (skips dependent and income)' do
+            is_expected.to eql(question_path(:claim))
+          end
+        end
       end
+
       context 'when the application is not a benefit one' do
         let(:benefits) { false }
 

--- a/spec/services/question_form_factory_spec.rb
+++ b/spec/services/question_form_factory_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe QuestionFormFactory do
       end
     end
 
+    context 'probate question' do
+      let(:id) { :probate }
+
+      context 'when the online_application is an ET one' do
+        let(:online_application) { build(:online_application, :et) }
+
+        it { is_expected.to be_a(Forms::Claim::Et) }
+      end
+
+      context 'when the online_application is not an ET one' do
+        it { is_expected.to be_a(Forms::Probate) }
+      end
+    end
+
     context 'for other existing question' do
       let(:id) { :marital_status }
 


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/aqCOKk0f/15-skip-step-8-probate-case-if-employment-tribunal)
[Original pivotal - for detail](https://www.pivotaltracker.com/n/projects/1212124/stories/121044203)

When a user has chosen ET as an option at question 1 there is no need to ask if it's a probate question later.

This handles both methods of routing to ensure the requirement. 