### PR TITLE
Add handler for nil time_taken

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -26,8 +26,17 @@ class ConfirmationsController < ApplicationController
   end
 
   def build_ga_event
-    time = storage.time_taken < 0 ? 1000 : storage.time_taken
+    time = calculate_time_taken
     type = online_application.benefits ? 'benefit' : 'income'
     ga_events << "ga('send', 'timing', 'Application', 'Complete', #{time}, '#{type}')"
+  end
+
+  def calculate_time_taken
+    return 0 unless storage_has_time?
+    storage.time_taken
+  end
+
+  def storage_has_time?
+    storage.started? && storage.time_taken > 0
   end
 end

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ConfirmationsController, type: :controller do
     allow(controller).to receive(:session).and_return(session)
     allow(Storage).to receive(:new).with(session).and_return(storage)
     allow(OnlineApplicationBuilder).to receive(:new).with(storage).and_return(builder)
+    allow(storage).to receive(:started?).and_return(true)
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
In certain circumstances, session did not have a start time.

This caused an error when calculating the time taken for the GA stats...
Added a handler to return 0 if started? or time_taken had not been set properly