### PR TITLE
Add `number` type to savings field

### DIFF
--- a/app/views/questions/forms/_savings_and_investment_extra.html.slim
+++ b/app/views/questions/forms/_savings_and_investment_extra.html.slim
@@ -20,4 +20,4 @@
           - else
             =t('amount_single', scope: @form.i18n_scope)
         span.currency £
-        = f.text_field :amount, class: 'form-control form-control-smaller'
+        = f.text_field :amount, type: 'number', class: 'form-control form-control-smaller'


### PR DESCRIPTION
Users were struggling to get the correct format for the extra savings field 
> , with  a comma, without, with pound sign, without etc. 

This adds a number field type to the input, it prevents text, `£`, etc, yet still allows `3,000.00` style entries.

It is what we use on the income input field, so this provides a standard approach to the fields