### PR TITLE
feature/rst 110 display probate option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ before_install:
 addons:
   code_climate:
     repo_token: ca58e966ca9664d66925f6837f4b2092de2b5eab7580591e955d3bb8be3b40fa
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script:
 - bundle exec rubocop
 - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'capybara-webkit'
   gem 'codeclimate-test-reporter', require: nil
   gem 'shoulda-matchers'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.12.0)
+      capybara (>= 2.3.0, < 2.13.0)
+      json
     codeclimate-test-reporter (1.0.5)
       simplecov
     coderay (1.1.1)
@@ -278,6 +281,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  capybara-webkit
   codeclimate-test-reporter
   config
   date_validator

--- a/app/assets/javascripts/modules/form-name.js
+++ b/app/assets/javascripts/modules/form-name.js
@@ -3,6 +3,8 @@
 window.moj.Modules.FormName = {
   $identifier: $('#form_name_identifier'),
   $unknown: $('#form_name_unknown'),
+  $probate: $("#form_name_probate"),
+  $continue: $("input.button"),
 
   init: function () {
     var self = this;
@@ -19,6 +21,10 @@ window.moj.Modules.FormName = {
       self.identifierKeyUp();
     });
 
+    self.$probate.on('click', function() {
+      self.probateClick();
+    })
+
     self.$unknown.on('click', function() {
       self.unknownClick();
     });
@@ -30,6 +36,13 @@ window.moj.Modules.FormName = {
     if (self.$identifier.val().length > 0 && self.$unknown.is(':checked')) {
       self.$unknown.attr('checked', false).closest('label').removeClass('selected');
     }
+  },
+
+  probateClick: function() {
+    var self = this;
+    var is_checked = self.$probate.is(':checked');
+
+    self.$continue.attr("disabled", is_checked);
   },
 
   unknownClick: function() {

--- a/app/views/questions/forms/_form_name.html.slim
+++ b/app/views/questions/forms/_form_name.html.slim
@@ -15,6 +15,11 @@
     = t('et', scope: @form.i18n_scope)
 
 .form-group
+  label.block-label for="form_name_probate"
+    = check_box_tag :form_name_probate
+    = t('probate', scope: @form.i18n_scope)
+
+.form-group
   details
     summary =t('details.summary', scope: @form.i18n_scope)
 

--- a/app/views/questions/forms/_form_name.html.slim
+++ b/app/views/questions/forms/_form_name.html.slim
@@ -14,10 +14,11 @@
     = f.check_box :et
     = t('et', scope: @form.i18n_scope)
 
-.form-group
-  label.block-label for="form_name_probate"
-    = check_box_tag :form_name_probate
-    = t('probate', scope: @form.i18n_scope)
+- if ProbateFeesSwitch.use_probate_fees_changes?
+  .form-group
+    label.block-label for="form_name_probate"
+      = check_box_tag :form_name_probate
+      = t('probate', scope: @form.i18n_scope)
 
 .form-group
   details

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -412,6 +412,7 @@ cy:
         summary: Help gydag enw neu rif y ffurflen
       et: Mae arnaf angen help gyda ffi tribiwnlys cyflogaeth
       example: Rhowch rif y ffurflen llys neu dribiwnlys ar gyfer y busnes llys y mae arnoch angen help gydag ef, er enghraifft ffurflen ‘C100’, ‘D8’ neu 'Hysbysiad o Apêl'
+      probate: I need help with a Probate fee
       text: Pa ffi llys neu dribiwnlys y mae arnoch chi angen help gyda hi?
       title: Enw neu rif y ffurflen
       unknown: Dydw i ddim yn gwybod enw neu rif y ffurflen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
         summary: Help with form name or number
       et: I need help with an employment tribunal fee
       example: Enter the court or tribunal form number for the court business you need help with, for example ‘C100’, ‘D8’ or ‘notice to appeal’ form.
+      probate: I need help with a Probate fee
       text: What court or tribunal fee do you need help with?
       title: Form name or number
       unknown: I don’t know the form name or number

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,4 +31,4 @@ income:
   per_child_increment: 245
   married_supplement: 160
 probate_fees:
-  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || '2017-05-01' %>
+  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || '2017-03-21' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,4 +31,4 @@ income:
   per_child_increment: 245
   married_supplement: 160
 probate_fees:
-  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || '2017-03-21' %>
+  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || "2017-03-22 15:00:00 0" %>

--- a/spec/features/pages/form_name_question_spec.rb
+++ b/spec/features/pages/form_name_question_spec.rb
@@ -25,5 +25,22 @@ RSpec.feature 'As a user' do
         expect(page).to have_content 'Enter the form name or number, or select \'I don’t know the form name or number\''
       end
     end
+
+    context 'choosing the probate fees option' do
+      before do
+        Capybara.current_driver = :webkit
+        Timecop.freeze(probate_fees_release_date) do
+          given_user_answers_questions_up_to(:form_name)
+        end
+      end
+
+      after { Timecop.return }
+
+      scenario 'I expect the submit button to be disabled' do
+        check 'form_name_probate'
+
+        expect(page).to have_css("input.button[name='commit'][disabled='disabled']")
+      end
+    end
   end
 end

--- a/spec/features/pages/form_name_question_spec.rb
+++ b/spec/features/pages/form_name_question_spec.rb
@@ -34,8 +34,6 @@ RSpec.feature 'As a user' do
         end
       end
 
-      after { Timecop.return }
-
       scenario 'I expect the submit button to be disabled' do
         check 'form_name_probate'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,6 +57,10 @@ RSpec.configure do |config|
   # particularly slow.
   config.profile_examples = 10 if ENV['RACK_ENV'].eql?('test')
 
+  Capybara::Webkit.configure do |config|
+    config.block_unknown_urls
+  end
+
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,6 +2,6 @@ require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.before(:all) do
-    WebMock.disable_net_connect!(allow: %w[codeclimate.com])
+    WebMock.disable_net_connect!(allow: %w[codeclimate.com 127.0.0.1])
   end
 end


### PR DESCRIPTION
This PR will add the probation option on the first page of the Help with Fees application. It is also set to be enabled on the 21st March 2017 for staging testings.