### PR TITLE
small changes for step 15 and 17

### DIFF
--- a/features/step_definitions/step_eighteen_steps.rb
+++ b/features/step_definitions/step_eighteen_steps.rb
@@ -39,7 +39,7 @@ Then(/^I should be able to go back and change my details:$/) do |urls|
   urls.rows.each_with_index do |url, index|
     your_details = step_eighteen_page.tbody.tr[index]
     expect(your_details.right_link['href']).to have_content url[0]
-    expect(your_details.right_link.text).to eq 'Change'
+    expect(your_details.right_link.text).to have_content 'Change'
   end
 end
 

--- a/features/step_definitions/step_fifteen_steps.rb
+++ b/features/step_definitions/step_fifteen_steps.rb
@@ -17,7 +17,8 @@ Given(/^I visit the page for step fifteen$/) do
 end
 
 When(/^I enter my title$/) do
-  expect(step_fifteen_page.form_group[0].text).to eq 'Title(Optional)'
+  expect(step_fifteen_page.form_group[0].text).to have_content 'Title'
+  expect(step_fifteen_page.hint.text).to eq '(Optional)'
   step_fifteen_page.title.set('Ms')
 end
 

--- a/features/step_definitions/step_seventeen_steps.rb
+++ b/features/step_definitions/step_seventeen_steps.rb
@@ -23,7 +23,8 @@ Then(/^I should see confirmation copy$/) do
 end
 
 When(/^I enter a valid email address$/) do
-  expect(step_seventeen_page.form_group[1].text).to have_content 'Email address (Optional)'
+  expect(step_seventeen_page.form_group[1].text).to have_content 'Email address'
+  expect(step_seventeen_page.hint.text).to eq '(Optional)'
   step_seventeen_page.contact_email.set('test@hmcts.net')
   common_page.continue_button.click
 end

--- a/features/support/page_objects/step_fifteen_page.rb
+++ b/features/support/page_objects/step_fifteen_page.rb
@@ -3,6 +3,7 @@ class StepFifteenPage < BasePage
   element :first_name, '#personal_detail_first_name'
   element :last_name, '#personal_detail_last_name'
   elements :form_group, '.form-group'
+  element :hint, '.hint'
 
   def load_page(page_version = nil)
     load(v: page_version)

--- a/features/support/page_objects/step_seventeen_page.rb
+++ b/features/support/page_objects/step_seventeen_page.rb
@@ -5,6 +5,7 @@ class StepSeventeenPage < BasePage
     element :span, 'span'
   end
   elements :form_group, '.form-group'
+  element :hint, '.hint'
 
   def load_page(page_version = nil)
     load(v: page_version)


### PR DESCRIPTION
Tests were passing in Chrome but failing when run using a headless browser. 
Strings are read slightly differently so I have separated the strings:
'Title (Optional)'
'Email address (Optional)'
to expect:
'Title'
'Email address'
'(Optional)'