### PR TITLE
Create Dockerfile for running saucelabs tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -15,4 +15,3 @@ ZENDESK_TOKEN=zendesk_token
 
 SAUCE_USERNAME=saucelabs_username
 SAUCE_ACCESS_KEY=saucelabs_auth_key
-SAUCE_URL=http://${SAUCE_USERNAME}:${SAUCE_ACCESS_KEY}@ondemand.saucelabs.com:80/wd/hub

--- a/Dockerfile.saucelabs
+++ b/Dockerfile.saucelabs
@@ -1,0 +1,35 @@
+FROM ruby:2.3.3
+
+# Install runit, nodejs
+# phantomjs requires libfontconfig
+RUN apt-get update && \
+    apt-get install -y runit nodejs wget bzip2 libfontconfig && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && rm -fr *Release* *Sources* *Packages* && \
+    truncate -s 0 /var/log/*log
+
+# Download and install PhantomJS
+ENV PHANTOMJS_VERSION 2.1.1
+ENV PHANTOMJS_DIR /phantomjs
+RUN wget -q --continue -P $PHANTOMJS_DIR "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" && \
+    tar -xaf $PHANTOMJS_DIR/phantomjs* --strip-components=1 --directory $PHANTOMJS_DIR
+ENV PATH $PHANTOMJS_DIR/bin:$PATH
+
+# Config bundler
+RUN bundle config --global frozen 1 && \
+    bundle config --global disable_shared_gems 1
+
+# Create app's root folder
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app's dependencies
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install
+
+# Copy the app files
+COPY . /usr/src/app
+
+# Run the tests on every supported browser
+CMD ["./bin/run_saucelabs"]

--- a/bin/run_saucelabs
+++ b/bin/run_saucelabs
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'yaml'
 
-# Didplay cucumber's output immediately to STDOUT
+# Display cucumber's output immediately to STDOUT
 $stdout.sync = true
 
 # Use the saucelabs capybara driver

--- a/bin/run_saucelabs
+++ b/bin/run_saucelabs
@@ -1,33 +1,34 @@
 #!/usr/bin/env ruby
-
 require 'yaml'
 
-browsers = YAML.load_file('features/support/saucelabs/browsers.yml')
+# Didplay cucumber's output immediately to STDOUT
+$stdout.sync = true
 
-browsers = browsers['saucelabs']['browsers']
+# Use the saucelabs capybara driver
 ENV['DRIVER'] = 'saucelabs'
 
+# Load the saucelabs settings
+settings = YAML.load_file('features/support/saucelabs/browsers.yml')
+browsers = settings['saucelabs']['browsers'].keys
+
+# Run the tests for each supported browser
 failed = []
 passed = []
 
 browsers.each do |browser|
-  ENV['SAUCELABS_BROWSER'] = browser.first
+  ENV['SAUCELABS_BROWSER'] = browser
 
-  puts
-  puts "Running tests on #{browser.first}"
-  $stdout.sync = true
+  p "Running tests on #{browser}"
   system("cucumber --tags @saucelabs", out: $stdout, err: :out)
-  puts
 
   if $?.success?
-    puts "[DEBUG]: Adding #{browser.first} in the passed array"
-    passed << browser.first
+    passed << browser
   else
-    puts "[DEBUG]: Adding #{browser.first} in the failed array"
-    failed << browser.first
+    failed << browser
   end
 end
 
+# Display results
 puts "\n\n"
-puts "#{passed.count} passed browsers:\n #{passed.inspect}"
-puts "#{failed.count} failed browsers:\n #{failed.inspect}"
+p "#{passed.count} passed browsers: #{passed.join(', ')}"
+p "#{failed.count} failed browsers: #{failed.join(', ')}"

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :poltergeist do |app|
 end
 
 Capybara.register_driver :saucelabs do |app|
-  browser = Settings.saucelabs.browsers.send(ENV['SAUCELABS_BROWSER']).to_h
+  browser = Settings.saucelabs.browsers.send(Settings.saucelabs.browser).to_h
 
   Capybara::Selenium::Driver.new(app, browser: :remote, url: Settings.saucelabs.url, desired_capabilities: browser)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,6 +11,7 @@ require 'capybara-screenshot/cucumber'
 require 'rest-client'
 require 'selenium-webdriver'
 
+require_relative './page_objects/base_page'
 
 Dir[File.dirname(__FILE__) + '/page_objects/**/*.rb'].each { |f| require f }
 

--- a/features/support/saucelabs/browsers.yml
+++ b/features/support/saucelabs/browsers.yml
@@ -1,11 +1,12 @@
 saucelabs:
   username: <%= ENV['SAUCE_USERNAME'] %>
-  auth_key: <%= ENV['SAUCE_ACCESS_KEY'] %>
-  url: <%= ENV['SAUCE_URL'] %>
+  access_key: <%= ENV['SAUCE_ACCESS_KEY'] %>
+  url: <%= "http://#{ENV['SAUCE_USERNAME']}:#{ENV['SAUCE_ACCESS_KEY']}@ondemand.saucelabs.com:80/wd/hub" %>
+  browser: <%= ENV['SAUCELABS_BROWSER'] || 'chrome_win_latest' %>
   browsers:
-    ie8:
+    ie8_win7:
       browserName: internet explorer
-      name: IE_8
+      name: IE8_Win7
       platform: Windows 7
       version: '8'
     ie9_win7:


### PR DESCRIPTION
This PR includes the Dockerfile for running the saucelabs test and some adjustments in few files to fit the container's needs. Also, it includes some clean up refactoring.

Warning: The CI is using the official saucelabs connect plugin to setup the tunnel, meaning that further setup is required to run this container on a local machine.