### PR TITLE
Use env var for the application's base url in Gatling

### DIFF
--- a/performance-tests/src/test/resources/application.conf
+++ b/performance-tests/src/test/resources/application.conf
@@ -6,6 +6,7 @@
 # For example
 
 baseUrl = "http://localhost:3000"
+baseUrl = ${?APP_URL}
 
 users = 10
 duration = 300


### PR DESCRIPTION
This allows to define dynamically the environment the Gatling tests will run against, with localhost being the default one.