### PR TITLE
Removed ignore hidden elements from capybara helper

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -27,19 +27,9 @@ When(/^I click continue$/) do
   common_page.continue_button.click
 end
 
-When(/^I click on help with '([^\"]*)'$/) do |help|
-  expect(group_common(1).help_with.text).to have_content help
-  group_common(1).help_with.click
-end
-
-When(/^I open '([^\"]*)'$/) do |help|
-  expect(group_common(2).help_with.text).to have_content help
-  group_common(2).help_with.click
-end
-
 When(/^I click on '([^\"]*)'$/) do |help|
-  expect(group_common(2).help_with.text).to have_content help
-  group_common(2).help_with.click
+  expect(common_page.help_with.text).to have_content help
+  common_page.help_with.click
 end
 
 And(/^I click on yes, cancel$/) do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -8,19 +8,17 @@ Given(/^I do not need help with an employment tribunal$/) do
 end
 
 When(/^I click on cancel application$/) do
-  restart_app = common_page.restart_application
-  expect(restart_app['value']).to eq 'Cancel application'
-  restart_app.click
+  common_page.restart_application.click
 end
 
 When(/^I see the are you sure copy$/) do
-  confirm = common_page.restart_confirm
-  expect(confirm.p.count).to eq 2
-  expect(confirm.p[0].text).to eq 'Are you sure you want to cancel your application?'
+  expect(common_page.restart_confirm).to have_yes_button
+  expect(common_page.restart_confirm).to have_are_you_sure
+  expect(common_page.restart_confirm).to have_if_you_cancel
 end
 
 When(/^I click on no, return to current application$/) do
-  common_page.restart_confirm.button[1].click
+  common_page.restart_confirm.no_button.click
 end
 
 When(/^I click continue$/) do
@@ -33,7 +31,7 @@ When(/^I click on '([^\"]*)'$/) do |help|
 end
 
 And(/^I click on yes, cancel$/) do
-  common_page.restart_confirm.button[0].click
+  common_page.restart_confirm.yes_button.click
 end
 
 Then(/^I should see '([^\"]*)' header$/) do |header|
@@ -62,8 +60,7 @@ Then(/^I should see the please note copy$/) do
 end
 
 Then(/^I should not see the cancel application options$/) do
-  expect(common_page.restart_confirm.button[0]).to_not be_visible
-  expect(common_page.restart_confirm.button[1]).to_not be_visible
+  expect(common_page).to_not have_restart_confirm
 end
 
 Then(/^I should remain on the page$/) do

--- a/features/step_definitions/step_twelve_steps.rb
+++ b/features/step_definitions/step_twelve_steps.rb
@@ -59,6 +59,7 @@ When(/^I enter a case, claim or notice to pay number$/) do
 end
 
 Then(/^I should see help with case number copy$/) do
-  case_number_copy = step_twelve_page.form_group[2].details_content
-  expect(case_number_copy.p.count).to eq 3
+  expect(step_twelve_page).to have_creates_reference_number_copy
+  expect(step_twelve_page).to have_ongoing_case_copy
+  expect(step_twelve_page).to have_dont_have_reference_number_copy
 end

--- a/features/step_four.feature
+++ b/features/step_four.feature
@@ -1,3 +1,5 @@
+@e2e
+
 Feature: Step four page
 
   Scenario: Displays step number
@@ -25,7 +27,7 @@ Feature: Step four page
 
   Scenario: Help with savings and investments
     Given I am a single person on the step four page
-    When I click on help with 'savings and investments'
+    When I click on 'Help with savings and investments'
     Then I should see help with savings and investments copy
 
   Scenario: Does not display reminder for single people

--- a/features/step_seven.feature
+++ b/features/step_seven.feature
@@ -25,5 +25,5 @@ Feature: Step seven page
     Then I should see 'financially dependent children' error message
 
   Scenario: Help with benefits
-    When I open 'Help with financially dependent children'
+    When I click on 'Help with financially dependent children'
     Then I should see help with financially dependent children copy

--- a/features/step_six.feature
+++ b/features/step_six.feature
@@ -34,5 +34,5 @@ Feature: Step six page
     Then I should see 'Select whether you're receiving one of the benefits listed' error message
 
   Scenario: Help with benefits
-    When I click on help with 'benefits'
+    When I click on 'Help with benefits'
     Then I should see help with benefits copy

--- a/features/step_thirteen.feature
+++ b/features/step_thirteen.feature
@@ -19,7 +19,7 @@ Feature: Step thirteen page
     Then I am taken to step 14 - What is your date of birth?
 
   Scenario: If you don't know your national insurance number
-    When I click on if you don't know your national insurance number
+    When I click on 'If you don’t know your National Insurance number'
     Then I should see if you don't know your national insurance number copy
 
   Scenario: Displays error message enter a valid national insurance number

--- a/features/step_three.feature
+++ b/features/step_three.feature
@@ -20,5 +20,5 @@ Feature: Step three page
     Then I am taken to step 4 - How much do you have in savings and investments?
 
   Scenario: Help with status
-    When I click on help with 'status'
+    When I click on 'Help with status'
     Then I should see help with status copy

--- a/features/step_twelve.feature
+++ b/features/step_twelve.feature
@@ -32,7 +32,7 @@ Feature: Step twelve page
   Scenario: Help with case number
     Given I do not need help with an employment tribunal
     And I go to step twelve without skipping step eleven
-    When I open 'Help with case number'
+    When I click on 'Help with case number'
     Then I should see help with case number copy
 
   Scenario: Displays enter a number error message

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -3,7 +3,6 @@ Capybara.configure do |config|
   config.default_driver = driver
   config.default_max_wait_time = 30
   config.match = :prefer_exact
-  config.ignore_hidden_elements = false
   config.visible_text_only = true
 end
 

--- a/features/support/page_objects/common_page.rb
+++ b/features/support/page_objects/common_page.rb
@@ -8,10 +8,8 @@ class CommonPage < BasePage
       elements :li, 'li'
       elements :hint, '.hint'
     end
-    sections :form_group, '.form-group' do
-      element :help_with, 'details > summary'
-    end
   end
+  element :help_with, 'details > summary'
 
   element :heading_secondary, '.heading-secondary'
   elements :block, '.block'

--- a/features/support/page_objects/common_page.rb
+++ b/features/support/page_objects/common_page.rb
@@ -13,10 +13,12 @@ class CommonPage < BasePage
 
   element :heading_secondary, '.heading-secondary'
   elements :block, '.block'
-  element :restart_application, '.restart-application'
+  element :restart_application, 'input[value="Cancel application"]'
   section :restart_confirm, '.restart-confirm' do
-    elements :p, 'p'
-    elements :button, 'button'
+    element :are_you_sure, 'p', text: 'Are you sure you want to cancel your application?'
+    element :if_you_cancel, 'p', text: 'If you cancel, details for your current application will be deleted.'
+    element :yes_button, '.button', text: 'Yes, cancel'
+    element :no_button, '.button', text: 'No, return to current application'
   end
   section :error_summary, '.error-summary' do
     element :error_summary_heading, '#error-summary-heading-example-1'

--- a/features/support/page_objects/step_twelve_page.rb
+++ b/features/support/page_objects/step_twelve_page.rb
@@ -6,9 +6,7 @@ class StepTwelvePage < BasePage
   element :claim_default_identifier, '#claim_default_identifier'
   element :claim_et_identifier, '#claim_et_identifier'
   element :form_label, '.form-label'
-  sections :form_group, '.form-group' do
-    section :details_content, '#details-content-0' do
-      elements :p, 'p'
-    end
-  end
+  element :creates_reference_number_copy, '.text', text: 'The court or tribunal creates a reference number for every case. This is sometimes called a claim number, case number, or ‘notice to pay’ number.'
+  element :ongoing_case_copy, '.text', text: 'If your case is ongoing then you’ll find the reference number on letters from the court or tribunal.'
+  element :dont_have_reference_number_copy, '.text', text: "Answer 'no' to this question if you don’t have a reference number (this might be because your case hasn’t started yet)."
 end


### PR DESCRIPTION
Removed ignore hidden elements from capybara helper as advised by Gary.
It broke some tests relating to 'Help with...' and 'Cancel application'. These have been fixed.
Further refactoring is recommended but out of scope for this task.