### PR TITLE
Fix for running ZAP Cucumber test in Firefox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,9 @@ group :test do
   gem 'chromedriver-helper', '~> 1.1'
   gem 'codeclimate-test-reporter', require: nil
   gem 'cucumber-rails', '~> 1.5'
+  gem 'geckodriver-helper', '~> 0.0'
   gem 'poltergeist', '1.15.0'
-  gem 'selenium-webdriver', '~> 3.4'
+  gem 'selenium-webdriver', '~> 3.10'
   gem 'shoulda-matchers'
   gem 'site_prism', '~> 2.9'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
-    childprocess (0.7.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.1.0)
       archive-zip (~> 0.7.0)
@@ -116,9 +116,11 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.23)
     foreman (0.83.0)
       thor (~> 0.19.1)
+    geckodriver-helper (0.0.4)
+      archive-zip (~> 0.7.0)
     gherkin (4.1.3)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -248,10 +250,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.4.0)
+    selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
+      rubyzip (~> 1.2)
     sentry-raven (2.5.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.1)
@@ -310,7 +311,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -337,6 +337,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl_rails
   foreman
+  geckodriver-helper (~> 0.0)
   govuk_elements_rails (= 0.3.0)
   govuk_frontend_toolkit (= 4.7.0)
   jquery-rails
@@ -351,7 +352,7 @@ DEPENDENCIES
   rubocop (~> 0.49.1)
   rubocop-rspec (~> 1.10)
   sass-rails
-  selenium-webdriver (~> 3.4)
+  selenium-webdriver (~> 3.10)
   sentry-raven
   shoulda-matchers
   site_prism (~> 2.9)
@@ -366,4 +367,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/features/step_definitions/zap_security_steps.rb
+++ b/features/step_definitions/zap_security_steps.rb
@@ -55,8 +55,8 @@ When(/^I take the happy path through steps 1 to 20$/) do
   # step eighteen
   step_eighteen_page.submit_button.click
   # step nineteen
-  common_page.button.click
+  common_page.continue_button.click
   # step twenty
-  common_page.button.click
+  step_twenty_page.finish_application_button.click
 end
 # rubocop:enable Metrics/BlockLength

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -34,7 +34,7 @@ Capybara.register_driver :safari do |app|
 end
 
 Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |scenario|
-  title = scenario.title.tr(' ', '-').gsub(%r{/^.*\/cucumber\//}, '')
+  title = scenario.name.tr(' ', '-').gsub(%r{/^.*\/cucumber\//}, '')
   "screenshot_cucumber_#{title}"
 end
 


### PR DESCRIPTION
Added geckodriver-helper
Updated Gemfile.lock
Changed scenario.title to scenario.name as advised on below
`#title is deprecated and will be removed after version 2.9.9. Call #name instead.`
Fixed step When I take the happy path through steps 1 to 20