### PR TITLE
Ask user's email instead of their phone in the ask for help page

### DIFF
--- a/app/models/forms/help_request.rb
+++ b/app/models/forms/help_request.rb
@@ -1,9 +1,9 @@
 module Forms
   class HelpRequest < Base
     attribute :name, String
-    attribute :phone, String
+    attribute :email, String
     attribute :description, String
 
-    validates :name, :phone, :description, presence: true
+    validates :name, :email, :description, presence: true
   end
 end

--- a/app/services/zendesk_sender.rb
+++ b/app/services/zendesk_sender.rb
@@ -27,13 +27,13 @@ class ZendeskSender
   end
 
   def subject(help_request)
-    "#{help_request.name} has requested assistance, please call them back on: #{help_request.phone}"
+    "#{help_request.name} has requested assistance, please email them back on: #{help_request.email}"
   end
 
   def custom_fields(help_request)
     [
       { id: '32342378', value: Settings.env },
-      { id: '24041286', value: help_request.phone },
+      { id: '24041286', value: help_request.email },
       { id: '23757677', value: 'help_with_fees_technical_support' }
     ]
   end

--- a/app/services/zendesk_sender.rb
+++ b/app/services/zendesk_sender.rb
@@ -27,7 +27,8 @@ class ZendeskSender
   end
 
   def subject(help_request)
-    "#{help_request.name} has requested assistance, please email them back on: #{help_request.email}"
+    "#{help_request.name} has requested assistance, " \
+    "please email them back on: #{help_request.email}"
   end
 
   def custom_fields(help_request)

--- a/app/views/help_requests/new.html.slim
+++ b/app/views/help_requests/new.html.slim
@@ -19,10 +19,10 @@ p =t('help_requests.description.line_2')
       span.error-message#name = @form.errors[:name].join(' ') if @form.errors[:name].any?
       = f.text_field :name, class: 'form-control'
 
-    .form-group class=('error' if @form.errors[:phone].any?)
-      = f.label :phone, class: 'form-label'
-      span.error-message#phone = @form.errors[:phone].join(' ') if @form.errors[:phone].any?
-      = f.text_field :phone, class: 'form-control'
+    .form-group class=('error' if @form.errors[:email].any?)
+      = f.label :email, class: 'form-label'
+      span.error-message#email = @form.errors[:email].join(' ') if @form.errors[:email].any?
+      = f.text_field :email, class: 'form-control'
 
     .form-group class=('error' if @form.errors[:description].any?)
       = f.label :description, class: 'form-label'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -19,7 +19,7 @@ cy:
         identifier: Enw neu rif y ffurflen
       forms/help_request:
         description: Disgrifiwch beth hoffech chi siarad amdano
-        phone: Rhif ffôn
+        email: Cyfeiriad e-bost
         name: Enw
       forms/income:
         child_benefit: Budd-dal Plant
@@ -113,8 +113,8 @@ cy:
               blank: Disgrifiwch beth hoffech chi siarad amdano.
             name:
               blank: Rhowch enw dilys.
-            phone:
-              blank: Rhowch rif ffôn dilys.
+            email:
+              blank: Rhowch gyfeiriad e-bost dilys.
         forms/income_amount:
           attributes:
             amount:
@@ -275,8 +275,8 @@ cy:
     connection_refused: Cysylltiad wedi'i wrthod
   help_requests:
     description:
-      line_1: Rhowch eich enw, rhif ffôn a disgrifiad byr o ba fath o help yr hoffech ei gael. Byddwn ni'n cysylltu â chi yn ystod y diwrnod gwaith nesaf rhwng 9am a 5pm.
-      line_2: Dim ond ar gyfer eich ffonio'n ôl y byddwn ni'n defnyddio'ch manylion. Peidiwch â chynnwys gwybodaeth bersonol, er enghraifft, cyfeiriad neu ddyddiad geni.
+      line_1: Rhowch eich enw, cyfeiriad e-bost a disgrifiad byr o ba fath o help yr hoffech ei gael Byddwn ni’n cysylltu â chi drwy e-bost yn ystod y diwrnod gwaith nesaf rhwng 9am a 5pm.
+      line_2: Byddwn bob amser yn ceisio eich helpu drwy e-bost, ond os hoffech inni eich ffonio, rhowch eich rhif ffôn yn y blwch disgrifiad. Dim ond ar gyfer cysylltu â chi y byddwn ni'n defnyddio'ch manylion. Peidiwch â chynnwys gwybodaeth bersonol, er enghraifft, cyfeiriad neu ddyddiad geni.
     heading: Gofynnwch am help technegol
     layout_nudge:
       link: help technegol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
         identifier: Form name or number
       forms/help_request:
         description: Describe what you'd like to talk about
-        phone: Telephone number
+        email: Email address
         name: Name
       forms/income:
         child_benefit: Child Benefit
@@ -113,8 +113,8 @@ en:
               blank: Describe what you'd like to talk about.
             name:
               blank: Enter a valid name.
-            phone:
-              blank: Enter a valid phone number.
+            email:
+              blank: Please provide a valid email address.
         forms/income_amount:
           attributes:
             amount:
@@ -276,8 +276,8 @@ en:
     connection_refused: Connection refused
   help_requests:
     description:
-      line_1: Enter your name, telephone number and a brief description of what you need help with. We'll get back to you during the next working day between 9am and 5pm.
-      line_2: We’ll only use your details to call you back. Don’t include any personal information, for example address or date of birth.
+      line_1: Enter your name, e-mail address and a brief description of what you need help with. We’ll get back to you by email during the next working day between 9am and 5pm.
+      line_2: We will always try and assist by email, but if you would like us to telephone you, please provide your telephone number in the description box. We’ll only use your details to contact you. Don’t include any personal information, for example address or date of birth.
     heading: Ask for technical help
     layout_nudge:
       link: technical help

--- a/spec/controllers/help_requests_controller_spec.rb
+++ b/spec/controllers/help_requests_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HelpRequestsController, type: :controller do
   end
 
   describe 'POST #create' do
-    let(:params) { { name: 'N', phone: 'P', description: 'D' } }
+    let(:params) { { name: 'N', email: 'E', description: 'D' } }
     let(:id) { :help_request }
     let(:form) { instance_double(Forms::HelpRequest, id: id, permitted_attributes: params.keys, update_attributes: nil, valid?: valid?) }
     let(:zendesk_sender) { instance_double(ZendeskSender, send_help_request: nil) }

--- a/spec/models/forms/help_request_spec.rb
+++ b/spec/models/forms/help_request_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe Forms::HelpRequest, type: :model do
   subject { described_class.new }
 
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:phone) }
+  it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:description) }
 end

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ZendeskSender do
 
     let(:config) { double(:url= => nil, :username= => nil, :token= => nil) }
     let(:client) { double }
-    let(:help_request) { double(name: 'NAME', phone: 'PHONE', description: 'DESCRIPTION') }
+    let(:help_request) { double(name: 'NAME', email: 'EMAIL', description: 'DESCRIPTION') }
 
     before do
       Settings.zendesk.enabled = true
@@ -40,14 +40,14 @@ RSpec.describe ZendeskSender do
     describe 'the Zendesk ticket content' do
       let(:attributes) do
         {
-          subject: 'NAME has requested assistance, please call them back on: PHONE',
+          subject: 'NAME has requested assistance, please email them back on: EMAIL',
           description: 'DESCRIPTION',
           requester: {
             name: 'NAME'
           },
           custom_fields: [
             { id: '32342378', value: 'test' },
-            { id: '24041286', value: 'PHONE' },
+            { id: '24041286', value: 'EMAIL' },
             { id: '23757677', value: 'help_with_fees_technical_support' }
           ]
         }


### PR DESCRIPTION
We want to remove the telephone number field to prevent users providing their telephone number and expecting a phone cal from the Help with Fees staff.