### PR TITLE
Fixing anchor bug and adding italic styling.

### DIFF
--- a/app/helpers/yaml_helper.rb
+++ b/app/helpers/yaml_helper.rb
@@ -17,7 +17,7 @@ module YamlHelper
   def add_header
     if @this_section[:title].present?
       @result << header_block do
-        header_text + anchor_tag
+        anchor_tag + header_text
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -629,7 +629,7 @@ en:
           - li: <a href="#general_data_protection_regulations_gdpr">General Data Protection Regulations (GDPR)</a>
           - li: <a href="#hmcts_privacy_notice">HMCTS privacy notice</a>
           - li: <a href="#disclaimer">Disclaimer</a>
-        - p: By using this ‘Help with Fees’ service you agree to our privacy policy and to these terms and conditions. Read them carefully.
+        - p: <i>By using this ‘Help with Fees’ service you agree to our privacy policy and to these terms and conditions. Read them carefully.</i>
     - title: General terms and conditions
       parts:
       - p: These terms and conditions affect your rights and liabilities under the law. They govern your use of, and relationship with, this ‘Help with Fees’ service. They do not apply to other Ministry of Justice (HM Courts and Tribunals Service) services, or to any department or service that is linked to in this service.


### PR DESCRIPTION
The anchor was after the heading which in Safari and Chrome looked like you are in the middle of paragraph not in the beginning.