### PR TITLE
RST 1250 Google Tag Manager

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,4 @@ class ApplicationController < ActionController::Base
     flash[:error] = t('session.expired_message')
     redirect_to(root_path)
   end
-
-  def ga_events
-    @ga_events ||= []
-  end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,7 +4,6 @@ class ConfirmationsController < ApplicationController
 
   def show
     prepare_view
-    build_ga_event
   end
 
   def done
@@ -13,12 +12,10 @@ class ConfirmationsController < ApplicationController
 
   def refund
     prepare_view
-    build_ga_event
   end
 
   def et
     prepare_view
-    build_ga_event
   end
 
   private
@@ -26,20 +23,5 @@ class ConfirmationsController < ApplicationController
   def prepare_view
     @online_application = online_application
     @result = storage.submission_result
-  end
-
-  def build_ga_event
-    time = calculate_time_taken
-    type = online_application.benefits ? 'benefit' : 'income'
-    ga_events << "ga('send', 'timing', 'Application', 'Complete', #{time}, '#{type}')"
-  end
-
-  def calculate_time_taken
-    return 0 unless storage_has_time?
-    storage.time_taken
-  end
-
-  def storage_has_time?
-    storage.started? && storage.time_taken.positive?
   end
 end

--- a/app/services/storage.rb
+++ b/app/services/storage.rb
@@ -19,12 +19,6 @@ class Storage
     @session[:started_at].present?
   end
 
-  def time_taken
-    return nil unless started?
-    seconds = (Time.zone.now - started_at).round
-    seconds * 1000 # GA needs milliseconds
-  end
-
   def save_form(form)
     @session['questions'] = {} unless @session['questions']
     @session['questions'][form.id] = form.as_json

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -45,15 +45,6 @@
 
 - content_for :javascripts
   = javascript_include_tag('application.js')
-  javascript:
-    $(document).ready(function () {
-      if ("#{@ga_events}" != "") {
-        var events = JSON.parse("#{@ga_events}".replace(/&quot;/g, '"').replace(/&#39;/g, '\''));
-        $(events).each(function (_index, event) {
-           eval(event);
-        });
-      }
-    });
 
 - content_for :footer_support_links
   li =link_to 'Help', 'http://www.gov.uk/help'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,9 @@
 - content_for :page_title
   = t('application.title')
 
+- content_for :head
+  = render 'shared/analytics'
+
 - content_for :proposition_header
   .header-proposition
     .content
@@ -15,6 +18,10 @@
 
 - content_for :js_gt_ie
   6
+
+- content_for :after_header
+  noscript
+    iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBQ9L9X" height="0" width="0" style="display:none;visibility:hidden"
 
 - content_for :content_override
   #wrapper.group
@@ -38,7 +45,6 @@
 
 - content_for :javascripts
   = javascript_include_tag('application.js')
-  = render 'shared/analytics'
   javascript:
     $(document).ready(function () {
       if ("#{@ga_events}" != "") {

--- a/app/views/shared/_analytics.html.slim
+++ b/app/views/shared/_analytics.html.slim
@@ -1,16 +1,15 @@
 javascript:
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date();
-    a = s.createElement(o),
-    m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-  ga('set', 'anonymizeIp', true);
-  ga('create', "#{Settings.analytics.id}", "#{Settings.analytics.domain}" , { 'allowLinker': true });
-  ga('send', 'pageview');
+  (function(w, d, s, l, i)\ {
+    w[l] = w[l] || [];
+    w[l].push(\{
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+    });
+    var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src =
+        'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, 'script', 'dataLayer', 'GTM-MBQ9L9X');

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ConfirmationsController, type: :controller do
   let(:online_application) { instance_double(OnlineApplication, benefits: true) }
   let(:result) { { result: true, message: 'HWF-010101' } }
   let(:storage_started) { true }
-  let(:storage) { instance_double(Storage, submission_result: result, time_taken: 600, started?: storage_started) }
+  let(:storage) { instance_double(Storage, submission_result: result, started?: storage_started) }
   let(:builder) { instance_double(OnlineApplicationBuilder, online_application: online_application) }
 
   before do

--- a/spec/services/storage_spec.rb
+++ b/spec/services/storage_spec.rb
@@ -130,28 +130,6 @@ RSpec.describe Storage do
     end
   end
 
-  describe '#time_taken' do
-    subject { storage.time_taken }
-
-    let(:session) { {} }
-
-    context 'when started_at is not set' do
-      it { is_expected.to be nil }
-    end
-
-    context 'when started_at is stored in the session as a string' do
-      let(:session) { { started_at: current_time.to_s } }
-
-      it { is_expected.to be_a Integer }
-    end
-
-    context 'when started_at is 10 minutes old' do
-      let(:session) { { started_at: current_time - 10.minutes } }
-
-      it { is_expected.to eq 600000 }
-    end
-  end
-
   describe '#save_form' do
     let(:id) { 'ID' }
     let(:json_data) { { some: 'data' } }


### PR DESCRIPTION
HWF will be using to use Google Tag Manager for managing Google Analytics events.

So, this PR replaces the GA snippet with the Tag Manager one and removes any custom GA code from the backend.