### PR TITLE
Upgrade gems with security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     foreman (0.83.0)
       thor (~> 0.19.1)
     geckodriver-helper (0.0.4)
@@ -244,7 +244,7 @@ GEM
     rubocop-rspec (1.10.0)
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -278,7 +278,7 @@ GEM
     slop (3.6.0)
     spring (2.0.1)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -370,4 +370,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
Security patches for:

- rubyzip [CVE-2018-1000544](https://nvd.nist.gov/vuln/detail/CVE-2018-1000544)
- ffi [CVE-2018-1000201](https://nvd.nist.gov/vuln/detail/CVE-2018-1000201)
- sprockets [CVE-2018-3760](https://nvd.nist.gov/vuln/detail/CVE-2018-3760)