### PR TITLE
gem update to fix firefox driver issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,9 @@ group :test do
   gem 'chromedriver-helper', '~> 1.1'
   gem 'codeclimate-test-reporter', require: nil
   gem 'cucumber-rails', '~> 1.5', require: false
-  gem 'geckodriver-helper', '~> 0.0'
+  gem 'geckodriver-helper', '~> 0.23.0'
   gem 'poltergeist', '1.15.0'
-  gem 'selenium-webdriver', '~> 3.10'
+  gem 'selenium-webdriver', '~> 3.141'
   gem 'shoulda-matchers'
   gem 'site_prism', '~> 2.9'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,11 +116,11 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     foreman (0.83.0)
       thor (~> 0.19.1)
-    geckodriver-helper (0.0.4)
-      archive-zip (~> 0.7.0)
+    geckodriver-helper (0.23.0)
+      archive-zip (~> 0.7)
     gherkin (4.1.3)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -254,9 +254,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.11.0)
+    selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.5.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.1)
@@ -341,7 +341,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl_rails
   foreman
-  geckodriver-helper (~> 0.0)
+  geckodriver-helper (~> 0.23.0)
   govuk_elements_rails (= 0.3.0)
   govuk_frontend_toolkit (= 4.7.0)
   jquery-rails
@@ -356,7 +356,7 @@ DEPENDENCIES
   rubocop (~> 0.60)
   rubocop-rspec (~> 1.10)
   sass-rails
-  selenium-webdriver (~> 3.10)
+  selenium-webdriver (~> 3.141)
   sentry-raven
   shoulda-matchers
   site_prism (~> 2.9)


### PR DESCRIPTION
Update gem 'selenium-webdriver' and 'geckodriver-helper' to fix this error:
newSession (Selenium::WebDriver::Error::UnknownError)
      WebDriverError@chrome://marionette/content/error.js:179:5
      UnknownCommandError@chrome://marionette/content/error.js:473:5