### PR TITLE
RST-1773 Updating text on NI number page to help users

### DIFF
--- a/app/views/questions/forms/_national_insurance.html.slim
+++ b/app/views/questions/forms/_national_insurance.html.slim
@@ -15,4 +15,4 @@
           li =t('item_1', scope: "#{@form.i18n_scope}.details.section_1")
           li =link_to t('item_2', scope: "#{@form.i18n_scope}.details.section_1"), 'https://www.gov.uk/lost-national-insurance-number', class: 'external', rel: 'external'
 
-        p =t('detail', scope: "#{@form.i18n_scope}.details.section_1")
+        p =t('detail_html', scope: "#{@form.i18n_scope}.details.section_1")

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -487,7 +487,7 @@ cy:
       breadcrumb: Cam 13 o 20
       details:
         section_1:
-          detail: Os na allwch chi ddarparu rhif Yswiriant Gwladol, bydd angen i chi ddarparu llythyr oddi wrth y Ganolfan Waith.
+          detail_html: Os na allwch chi ddarparu rhif Yswiriant Gwladol, bydd angen i chi ddarparu llythyr oddi wrth y Ganolfan Waith.
           item_1: chwiliwch am eich rhif Yswiriant Gwladol ar slipiau cyflog neu lythyrau swyddogol am dreth, pensiynau neu fudd-daliadau
           item_2: gofynnwch am nodyn atgoffa drwy'r post
         summary: Os nad ydych chi'n gwybod eich rhif Yswiriant Gwladol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,7 +488,7 @@ en:
       breadcrumb: Step 13 of 20
       details:
         section_1:
-          detail: If you can’t provide a National Insurance number you will need to provide a letter from the Jobcentre.
+          detail_html: "If you don't have a National Insurance number, you need to <a href='https://www.gov.uk/government/publications/apply-for-help-with-court-and-tribunal-fees' title='Form EX160: Apply for help with court and tribunal fees' target='_blank'>use the paper form</a>."
           item_1: look for your National Insurance number on payslips or official letters about tax, pensions or benefits
           item_2: ask for a reminder through the post
         summary: If you don’t know your National Insurance number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,7 +488,10 @@ en:
       breadcrumb: Step 13 of 20
       details:
         section_1:
-          detail_html: "If you don't have a National Insurance number, you need to <a href='https://www.gov.uk/government/publications/apply-for-help-with-court-and-tribunal-fees' title='Form EX160: Apply for help with court and tribunal fees' target='_blank'>use the paper form</a>."
+          detail_html: "If you don't have a National Insurance number, you need to <br />
+            <a href='https://www.gov.uk/government/publications/apply-for-help-with-court-and-tribunal-fees'
+            class='external' rel='external noopener' title='Form EX160: Apply for help with court and tribunal fees'
+            target='_blank'>use the paper form</a>."
           item_1: look for your National Insurance number on payslips or official letters about tax, pensions or benefits
           item_2: ask for a reminder through the post
         summary: If you don’t know your National Insurance number

--- a/features/step_definitions/national_insurance_steps.rb
+++ b/features/step_definitions/national_insurance_steps.rb
@@ -21,6 +21,7 @@ Then(/^I should see if you don't know your national insurance number copy$/) do
   expect(national_insurance_page.content).to have_look_for_ni_text
   expect(national_insurance_page.content.ask_for_reminder_link['href']).to eq 'https://www.gov.uk/lost-national-insurance-number'
   expect(national_insurance_page.content).to have_no_ni_number_text
+  expect(national_insurance_page.content).to have_no_ni_number_link
 end
 
 Then(/^I should see enter a valid National Insurance number error message$/) do

--- a/features/support/page_objects/national_insurance_page.rb
+++ b/features/support/page_objects/national_insurance_page.rb
@@ -9,7 +9,8 @@ class NationalInsurancePage < BasePage
     element :help_with_ni_dropdown, 'summary', text: 'If you don’t know your National Insurance number'
     element :look_for_ni_text, 'li', text: 'look for your National Insurance number on payslips or official letters about tax, pensions or benefits'
     element :ask_for_reminder_link, 'a', text: 'ask for a reminder through the post'
-    element :no_ni_number_text, 'p', text: "If you don't have a National Insurance number, you need to use the paper form."
+    element :no_ni_number_text, 'p', text: "If you don't have a National Insurance number, you need to"
+    element :no_ni_number_link, 'a', text: "use the paper form"
     element :blank_error_link, 'a', text: 'Enter your National Insurance number'
     element :blank_error_message, '.error-message', text: 'Enter your National Insurance number'
     element :invalid_error_link, 'a', text: 'Enter a valid National Insurance number'

--- a/features/support/page_objects/national_insurance_page.rb
+++ b/features/support/page_objects/national_insurance_page.rb
@@ -9,7 +9,7 @@ class NationalInsurancePage < BasePage
     element :help_with_ni_dropdown, 'summary', text: 'If you don’t know your National Insurance number'
     element :look_for_ni_text, 'li', text: 'look for your National Insurance number on payslips or official letters about tax, pensions or benefits'
     element :ask_for_reminder_link, 'a', text: 'ask for a reminder through the post'
-    element :no_ni_number_text, 'p', text: 'If you can’t provide a National Insurance number you will need to provide a letter from the Jobcentre.'
+    element :no_ni_number_text, 'p', text: "If you don't have a National Insurance number, you need to use the paper form."
     element :blank_error_link, 'a', text: 'Enter your National Insurance number'
     element :blank_error_message, '.error-message', text: 'Enter your National Insurance number'
     element :invalid_error_link, 'a', text: 'Enter a valid National Insurance number'


### PR DESCRIPTION
There is no clear guidance on the digital channel for citizens who don't have a NI number. This statement directs them to complete a paper form, which is correct and agreed process.