### PR TITLE
Changing the alternative date if the env is missing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,5 +30,5 @@ income:
   per_child_increment: 245
   married_supplement: 160
 probate_fees:
-  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || '2019-03-01' %>
+  release_date: <%= ENV['PROBATE_FEES_RELEASE_DATE'] || '2025-04-01' %>
 

--- a/spec/features/pages/form_name_question_spec.rb
+++ b/spec/features/pages/form_name_question_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.feature 'As a user' do
   context 'when accessing the "form-name" page for "Help with fees"' do
-    before { given_user_answers_questions_up_to(:form_name) }
 
     context 'completing the form correctly' do
       before do
+        given_user_answers_questions_up_to(:form_name)
         fill_in :form_name_identifier, with: 'N1'
         click_button 'Continue'
       end
@@ -17,6 +17,7 @@ RSpec.feature 'As a user' do
 
     context 'not completing the page correctly' do
       before do
+        given_user_answers_questions_up_to(:form_name)
         click_button 'Continue'
       end
 
@@ -39,10 +40,15 @@ RSpec.feature 'As a user' do
     end
 
     context 'when probate fees are no longer supported' do
+      before do
+        travel_to(probate_fees_release_date)
+        given_user_answers_questions_up_to(:form_name)
+      end
+
+      after { travel_back }
+
       scenario 'I expect a warning message to be displayed' do
-        travel_to(probate_fees_release_date) do
-          expect(page).to have_css('#probate-warning')
-        end
+        expect(page).to have_css('#probate-warning')
       end
     end
 
@@ -62,6 +68,7 @@ RSpec.feature 'As a user' do
     context 'when probate fees are no longer supported' do
       scenario 'I expect a warning message to be displayed' do
         Timecop.freeze(probate_fees_release_date) do
+          given_user_answers_questions_up_to(:form_name)
           expect(page).to have_css('#probate-warning')
         end
       end

--- a/spec/features/pages/income_question_spec.rb
+++ b/spec/features/pages/income_question_spec.rb
@@ -4,35 +4,6 @@ RSpec.feature 'As a user' do
   context 'when accessing the "income_kind" page for "Help with fees"' do
     before { given_user_answers_questions_up_to(:income_kind) }
 
-    context 'completing the form correctly' do
-      context 'when "no income" selected' do
-        before do
-          travel_to a_day_before_disable_probate_fees
-          check :income_kind_applicant_13
-          click_button 'Continue'
-        end
-
-        after { travel_back }
-
-        scenario 'I expect to be routed to the "probate" page' do
-          expect(page).to have_content 'Are you paying a fee for a probate case?'
-        end
-
-      end
-
-      context 'when some income sources selected' do
-        before do
-          check :income_kind_applicant_2
-          check :income_kind_applicant_8
-          click_button 'Continue'
-        end
-
-        scenario 'I expect to be routed to the "income_range" page' do
-          expect(page).to have_content 'How much income do you receive each month?'
-        end
-      end
-    end
-
     context 'not completing the page correctly' do
       before do
         click_button 'Continue'
@@ -102,6 +73,38 @@ RSpec.feature 'As a user' do
         expect(page).to have_content 'What’s your total monthly income?'
         expect(page).to have_content 'There is a problem'
         expect(page).to have_xpath('//span[@class="error-message"]', text: 'Enter how much income do you receive')
+      end
+    end
+  end
+
+  context 'when accessing the "income_kind" before probate is disabled' do
+    context 'completing the form correctly' do
+      context 'when "no income" selected' do
+        before do
+          travel_to a_day_before_disable_probate_fees
+          given_user_answers_questions_up_to(:income_kind)
+          check :income_kind_applicant_13
+          click_button 'Continue'
+        end
+
+        after { travel_back }
+
+        scenario 'I expect to be routed to the "probate" page' do
+          expect(page).to have_content 'Are you paying a fee for a probate case?'
+        end
+      end
+
+      context 'when some income sources selected' do
+        before do
+          given_user_answers_questions_up_to(:income_kind)
+          check :income_kind_applicant_2
+          check :income_kind_applicant_8
+          click_button 'Continue'
+        end
+
+        scenario 'I expect to be routed to the "income_range" page' do
+          expect(page).to have_content 'How much income do you receive each month?'
+        end
       end
     end
   end


### PR DESCRIPTION
To make sure that if the ENV value for probate switch is not there we are still not going to switch it on.