### PR TITLE
Take user to yes radio instead of form when click error link

### DIFF
--- a/app/views/questions/forms/national_insurance/_national_insurance.html.slim
+++ b/app/views/questions/forms/national_insurance/_national_insurance.html.slim
@@ -1,11 +1,11 @@
-.govuk-form-group id='national_insurance_ni_number_present' class=('govuk-form-group--error' if @form.errors[:partner_national_insurance].any?)
+.govuk-form-group class=('govuk-form-group--error' if @form.errors[:partner_national_insurance].any?)
   - if @form.errors[:ni_number_present].any?
     span.govuk-error-message#kase = @form.errors[:ni_number_present].join(' ')
   .govuk-form-group
     .govuk-radios
       .govuk-radios__item
-        = f.radio_button :ni_number_present, 'true', class: 'govuk-radios__input', 'data-target': "ni-number-panel"
-        label.govuk-label.govuk-radios__label for='national_insurance_ni_number_present_true'
+        = f.radio_button :ni_number_present, 'true', class: 'govuk-radios__input', 'data-target': "ni-number-panel", id: 'national_insurance_ni_number_present'
+        label.govuk-label.govuk-radios__label for='national_insurance_ni_number_present'
           = t('ni_number_present_true', scope: @form.i18n_scope)
 
       .govuk-radios__conditional#ni-number-panel.visuallyhidden

--- a/spec/features/pages/national_insurance_question_spec.rb
+++ b/spec/features/pages/national_insurance_question_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'As a user' do
 
       describe 'clicking yes and leaving the ni field empty' do
         before do
-          choose 'national_insurance_ni_number_present_true'
+          choose 'national_insurance_ni_number_present'
           click_button 'Continue'
         end
 
@@ -42,7 +42,7 @@ RSpec.feature 'As a user' do
 
       describe 'providing an incorrect value' do
         before do
-          choose 'national_insurance_ni_number_present_true'
+          choose 'national_insurance_ni_number_present'
           fill_in 'national_insurance_number', with: 'AB123'
           click_button 'Continue'
         end

--- a/spec/support/feature_steps.rb
+++ b/spec/support/feature_steps.rb
@@ -245,7 +245,7 @@ module FeatureSteps
   end
 
   def fill_national_insurance
-    choose 'national_insurance_ni_number_present_true'
+    choose 'national_insurance_ni_number_present'
     fill_in 'national_insurance_number', with: 'AB123456A'
     click_button 'Continue'
   end


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RST-7125

Accessibility reviews state that error link 'Select yes if you have National Insurance number' from national insurance number page should take users to the yes radio button instead of the whole form.

This PR implements this.